### PR TITLE
Silence Julia kernel noise on startup; expose latestVersion metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -521,8 +521,7 @@
         {
           "when": "resourceExtname == .jl || editorLangId == julia",
           "command": "julia.debugEditorContents",
-          "group": "navigation",
-          "order": 3
+          "group": "navigation@46"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -510,12 +510,6 @@
           "command": "julia.runSelection",
           "group": "navigation",
           "order": 2
-        },
-        {
-          "when": "resourceExtname == .jl || editorLangId == julia",
-          "command": "julia.debugEditorContents",
-          "group": "navigation",
-          "order": 3
         }
       ],
       "editor/actions/left": [
@@ -523,6 +517,12 @@
           "when": "resourceExtname == .jl || editorLangId == julia",
           "command": "julia.toggleOutline",
           "group": "navigation@45"
+        },
+        {
+          "when": "resourceExtname == .jl || editorLangId == julia",
+          "command": "julia.debugEditorContents",
+          "group": "navigation",
+          "order": 3
         }
       ]
     },

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -169,6 +169,60 @@ function _positron_search_packages(query::String)
     _positron_print_json_packages(packages)
 end
 
+function _positron_print_json_metadata(by_name::Dict{String,String})
+    print("{")
+    first = true
+    for (name, version) in by_name
+        first || print(",")
+        first = false
+        print(_positron_json_string(lowercase(name)), ":{")
+        print("\"latestVersion\":", _positron_json_string(version))
+        print("}")
+    end
+    print("}")
+end
+
+function _positron_package_metadata(names::Vector{String})
+    targets = Set{String}()
+    for raw in names
+        cleaned = strip(raw)
+        isempty(cleaned) || push!(targets, String(cleaned))
+    end
+    by_name = Dict{String,String}()
+
+    if isempty(targets)
+        _positron_print_json_metadata(by_name)
+        return
+    end
+
+    for registry in Pkg.Registry.reachable_registries()
+        for entry in values(registry.pkgs)
+            entry.name in targets || continue
+
+            version = try
+                _positron_latest_registry_version(entry)
+            catch
+                "0"
+            end
+
+            previous = get(by_name, entry.name, nothing)
+            if previous === nothing
+                by_name[entry.name] = version
+            elseif previous != version
+                try
+                    if previous == "0" || VersionNumber(version) > VersionNumber(previous)
+                        by_name[entry.name] = version
+                    end
+                catch
+                    # Keep the existing version if parsing fails.
+                end
+            end
+        end
+    end
+
+    _positron_print_json_metadata(by_name)
+end
+
 function _positron_search_package_versions(name::String)
     target = lowercase(strip(name))
     versions = Set{VersionNumber}()

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -183,10 +183,12 @@ function _positron_print_json_metadata(by_name::Dict{String,String})
 end
 
 function _positron_package_metadata(names::Vector{String})
+    # Match registry entries case-insensitively so callers can pass either
+    # canonical (`Revise`) or lower-cased (`revise`) package names.
     targets = Set{String}()
     for raw in names
         cleaned = strip(raw)
-        isempty(cleaned) || push!(targets, String(cleaned))
+        isempty(cleaned) || push!(targets, lowercase(String(cleaned)))
     end
     by_name = Dict{String,String}()
 
@@ -197,7 +199,7 @@ function _positron_package_metadata(names::Vector{String})
 
     for registry in Pkg.Registry.reachable_registries()
         for entry in values(registry.pkgs)
-            entry.name in targets || continue
+            lowercase(entry.name) in targets || continue
 
             version = try
                 _positron_latest_registry_version(entry)

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -379,36 +379,44 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 
 		return new Promise((resolve, reject) => {
 			let settled = false;
+			let listenersDisposed = false;
 			let timeoutHandle: NodeJS.Timeout | undefined;
+			let listenerForceCleanupHandle: NodeJS.Timeout | undefined;
 			let messageDisposable: vscode.Disposable | undefined;
 			let suppressDisposable: vscode.Disposable | undefined;
 			let cancelDisposable: vscode.Disposable | undefined;
 
-			const cleanup = () => {
-				if (timeoutHandle) {
-					clearTimeout(timeoutHandle);
+			// Kernel listeners and suppression are torn down only when the
+			// kernel reports Idle (or after a hard timeout safety net). This
+			// matters because Silent queries that are cancelled mid-flight are
+			// not interrupted on the kernel side — keeping the suppression
+			// listener alive ensures any output the kernel still produces is
+			// silently discarded.
+			const disposeListeners = () => {
+				if (listenersDisposed) {
+					return;
+				}
+				listenersDisposed = true;
+				if (listenerForceCleanupHandle) {
+					clearTimeout(listenerForceCleanupHandle);
+					listenerForceCleanupHandle = undefined;
 				}
 				suppressDisposable?.dispose();
 				messageDisposable?.dispose();
+			};
+
+			const settle = (action: () => void) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				if (timeoutHandle) {
+					clearTimeout(timeoutHandle);
+					timeoutHandle = undefined;
+				}
 				cancelDisposable?.dispose();
-			};
-
-			const finishResolve = () => {
-				if (settled) {
-					return;
-				}
-				settled = true;
-				cleanup();
-				resolve({ stdout, stderr });
-			};
-
-			const finishReject = (error: unknown) => {
-				if (settled) {
-					return;
-				}
-				settled = true;
-				cleanup();
-				reject(error instanceof Error ? error : new Error(String(error)));
+				cancelDisposable = undefined;
+				action();
 			};
 
 			if (token?.isCancellationRequested) {
@@ -417,12 +425,26 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 			}
 
 			cancelDisposable = token?.onCancellationRequested(() => {
-				this._session.interrupt().catch(() => { /* best-effort */ });
-				finishReject(new vscode.CancellationError());
+				// For Silent (background) queries, do NOT interrupt the kernel.
+				// Interrupt is kernel-wide in Jupyter and raises an
+				// InterruptException whose error message Positron's supervisor
+				// surfaces to the console regardless of our session-level
+				// message suppression. Just abandon the awaited result; the
+				// listener stays alive until the kernel finishes the query on
+				// its own and reports Idle.
+				if (mode !== positron.RuntimeCodeExecutionMode.Silent) {
+					this._session.interrupt().catch(() => { /* best-effort */ });
+				}
+				settle(() => reject(new vscode.CancellationError()));
 			});
 
 			timeoutHandle = setTimeout(() => {
-				finishReject(new Error(`Timed out waiting for Julia package command to finish (${timeoutMs}ms)`));
+				settle(() => reject(new Error(`Timed out waiting for Julia package command to finish (${timeoutMs}ms)`)));
+				// Safety net: if Idle never arrives after a timeout, force
+				// listener teardown so we don't leak the suppression entry.
+				if (!listenersDisposed) {
+					listenerForceCleanupHandle = setTimeout(disposeListeners, 30_000);
+				}
 			}, timeoutMs);
 
 			if (mode === positron.RuntimeCodeExecutionMode.Silent) {
@@ -447,16 +469,17 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 					case positron.LanguageRuntimeMessageType.Error: {
 						const errorMessage = message as positron.LanguageRuntimeError;
 						const traceback = errorMessage.traceback?.join('\n') ?? '';
-						finishReject(new Error(
+						settle(() => reject(new Error(
 							`Julia package command failed: ${errorMessage.name}: ${errorMessage.message}` +
 							(traceback ? `\n${traceback}` : '')
-						));
+						)));
 						break;
 					}
 					case positron.LanguageRuntimeMessageType.State: {
 						const stateMessage = message as positron.LanguageRuntimeState;
 						if (stateMessage.state === positron.RuntimeOnlineState.Idle) {
-							finishResolve();
+							settle(() => resolve({ stdout, stderr }));
+							disposeListeners();
 						}
 						break;
 					}
@@ -473,7 +496,8 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 					positron.RuntimeErrorBehavior.Continue
 				);
 			} catch (error) {
-				finishReject(error);
+				settle(() => reject(error instanceof Error ? error : new Error(String(error))));
+				disposeListeners();
 			}
 		});
 	}

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as positron from 'positron';
@@ -195,6 +197,26 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 		return this._parseStringArray(raw);
 	}
 
+	async getPackageMetadata(
+		packageNames: string[],
+		token?: vscode.CancellationToken
+	): Promise<Map<string, Partial<positron.LanguageRuntimePackage>>> {
+		const cleaned = packageNames
+			.map((name) => name.trim())
+			.filter((name) => name.length > 0);
+		if (cleaned.length === 0) {
+			return new Map();
+		}
+		await this.sourcePackagesScript();
+		const raw = await this._executeAndCapture(
+			`_positron_package_metadata(${this._toJuliaStringVector(cleaned)})`,
+			positron.RuntimeCodeExecutionMode.Silent,
+			QUERY_TIMEOUT_MS,
+			token
+		);
+		return this._parseMetadata(raw);
+	}
+
 	private _parsePackages(raw: string): positron.LanguageRuntimePackage[] {
 		const parsed = this._parseJsonValue(raw);
 		if (!Array.isArray(parsed)) {
@@ -223,6 +245,32 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 			return [];
 		}
 		return parsed.filter((item): item is string => typeof item === 'string');
+	}
+
+	private _parseMetadata(raw: string): Map<string, Partial<positron.LanguageRuntimePackage>> {
+		const result = new Map<string, Partial<positron.LanguageRuntimePackage>>();
+		const parsed = this._parseJsonValue(raw);
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			return result;
+		}
+		for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+			if (!value || typeof value !== 'object') {
+				continue;
+			}
+			const record = value as Record<string, unknown>;
+			const partial: Partial<positron.LanguageRuntimePackage> = {};
+			if (typeof record.latestVersion === 'string' && record.latestVersion.length > 0) {
+				partial.latestVersion = record.latestVersion;
+			}
+			if (typeof record.license === 'string' && record.license.length > 0) {
+				partial.license = record.license;
+			}
+			if (typeof record.publishedDate === 'string' && record.publishedDate.length > 0) {
+				partial.publishedDate = record.publishedDate;
+			}
+			result.set(key, partial);
+		}
+		return result;
 	}
 
 	private _parseJsonValue(raw: string): unknown {
@@ -277,8 +325,30 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 		timeoutMs: number = QUERY_TIMEOUT_MS,
 		token?: vscode.CancellationToken
 	): Promise<string> {
-		const result = await this._execute(code, mode, timeoutMs, token);
-		return result.stdout;
+		// Capture stdout via a temp file rather than the kernel's stream messages.
+		// Positron's runtime supervisor surfaces stream output to the console even
+		// for Silent executions, which leaked the raw packages JSON to the user.
+		// Redirecting stdout into a file inside Julia means the kernel emits no
+		// stream messages for these queries at all.
+		const tempFile = path.join(os.tmpdir(), `positron-julia-${crypto.randomUUID()}.txt`);
+		const escapedPath = this._escapeJuliaStringLiteral(tempFile);
+		const wrappedCode =
+			`let __positron_io = open("${escapedPath}", "w")\n` +
+			`try\n` +
+			`redirect_stdout(__positron_io) do\n` +
+			`${code}\n` +
+			`end\n` +
+			`finally\n` +
+			`close(__positron_io)\n` +
+			`end\n` +
+			`end`;
+
+		try {
+			await this._execute(wrappedCode, mode, timeoutMs, token);
+			return await fs.promises.readFile(tempFile, 'utf-8');
+		} finally {
+			fs.promises.unlink(tempFile).catch(() => { /* ignore cleanup errors */ });
+		}
 	}
 
 	private async _executeAndWait(

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -424,6 +424,16 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 				return;
 			}
 
+			// Safety net used after cancellation and timeout: if the kernel
+			// never reports Idle, we still need to tear down the suppression
+			// listener so it doesn't survive indefinitely.
+			const scheduleForceListenerCleanup = () => {
+				if (listenersDisposed || listenerForceCleanupHandle) {
+					return;
+				}
+				listenerForceCleanupHandle = setTimeout(disposeListeners, 30_000);
+			};
+
 			cancelDisposable = token?.onCancellationRequested(() => {
 				// For Silent (background) queries, do NOT interrupt the kernel.
 				// Interrupt is kernel-wide in Jupyter and raises an
@@ -436,15 +446,15 @@ export class JuliaPackageManager implements positron.LanguageRuntimePackageManag
 					this._session.interrupt().catch(() => { /* best-effort */ });
 				}
 				settle(() => reject(new vscode.CancellationError()));
+				// settle() has cleared the timeout, so without scheduling
+				// another forced cleanup the suppression listener could leak
+				// if the kernel never returns to Idle (e.g. a hung registry).
+				scheduleForceListenerCleanup();
 			});
 
 			timeoutHandle = setTimeout(() => {
 				settle(() => reject(new Error(`Timed out waiting for Julia package command to finish (${timeoutMs}ms)`)));
-				// Safety net: if Idle never arrives after a timeout, force
-				// listener teardown so we don't leak the suppression entry.
-				if (!listenersDisposed) {
-					listenerForceCleanupHandle = setTimeout(disposeListeners, 30_000);
-				}
+				scheduleForceListenerCleanup();
 			}, timeoutMs);
 
 			if (mode === positron.RuntimeCodeExecutionMode.Silent) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -117,9 +117,44 @@ export class JuliaSession implements positron.LanguageRuntimeSession, vscode.Dis
 		if (!this._kernel) {
 			return;
 		}
+
+		const executionId = `revise-autoload-${Date.now()}`;
+		const suppressDisposable = this.suppressRuntimeMessages(executionId);
+
+		let idleListener: vscode.Disposable | undefined;
+		let timeoutHandle: NodeJS.Timeout | undefined;
+		const cleanup = () => {
+			idleListener?.dispose();
+			idleListener = undefined;
+			if (timeoutHandle) {
+				clearTimeout(timeoutHandle);
+				timeoutHandle = undefined;
+			}
+			suppressDisposable.dispose();
+		};
+
+		idleListener = this.onDidReceiveRuntimeMessageRaw((msg) => {
+			if (msg.parent_id !== executionId) {
+				return;
+			}
+			if (msg.type === positron.LanguageRuntimeMessageType.State) {
+				const stateMsg = msg as positron.LanguageRuntimeState;
+				if (stateMsg.state === positron.RuntimeOnlineState.Idle) {
+					cleanup();
+				}
+			}
+		});
+
+		// Safety net in case Idle never arrives (precompilation can take a while).
+		timeoutHandle = setTimeout(cleanup, 10 * 60 * 1000);
+
+		// redirect_stderr/redirect_stdout silence the `[ Info: Precompiling ...]`
+		// noise and any SYSTEM task-error printing that Julia emits while loading
+		// Revise. Without this the messages reach IJulia's captured streams and
+		// surface in the console even though the execution is Silent.
 		this._kernel.execute(
-			`try; @eval import Revise; catch; end`,
-			`revise-autoload-${Date.now()}`,
+			`try; redirect_stderr(devnull) do; redirect_stdout(devnull) do; @eval import Revise; end; end; catch; end`,
+			executionId,
 			positron.RuntimeCodeExecutionMode.Silent,
 			positron.RuntimeErrorBehavior.Continue
 		);

--- a/src/session.ts
+++ b/src/session.ts
@@ -152,13 +152,22 @@ export class JuliaSession implements positron.LanguageRuntimeSession, vscode.Dis
 		// noise and any SYSTEM task-error printing that Julia emits while loading
 		// Revise. Without this the messages reach IJulia's captured streams and
 		// surface in the console even though the execution is Silent.
-		this._kernel.execute(
-			`try; redirect_stderr(devnull) do; redirect_stdout(devnull) do; @eval import Revise; end; end; catch; end`,
-			executionId,
-			positron.RuntimeCodeExecutionMode.Silent,
-			positron.RuntimeErrorBehavior.Continue
-		);
-		LOGGER.debug('Revise.jl auto-load attempted');
+		try {
+			this._kernel.execute(
+				`try; redirect_stderr(devnull) do; redirect_stdout(devnull) do; @eval import Revise; end; end; catch; end`,
+				executionId,
+				positron.RuntimeCodeExecutionMode.Silent,
+				positron.RuntimeErrorBehavior.Continue
+			);
+			LOGGER.debug('Revise.jl auto-load attempted');
+		} catch (error) {
+			// If the kernel rejects the execute call synchronously (e.g. the
+			// session ended during startup), tear down the suppression entry
+			// and listeners immediately so they don't linger for the full
+			// 10-minute safety window.
+			cleanup();
+			LOGGER.warn(`Revise.jl auto-load failed to dispatch: ${error}`);
+		}
 	}
 
 	dispose(): void {


### PR DESCRIPTION
## Summary
Three independent improvements to the Julia Packages pane experience:

1. **Silences console noise on first session start** — the precompilation `[ Info: ...]` lines, `SYSTEM:` task-error prints, and `Package refresh timed out` cascade that appeared every time a user opened a new Julia session.
2. **Removes the raw packages JSON leak** that surfaced in the console after the first packages refresh.
3. **Implements `getPackageMetadata`** (the optional API added in [posit-dev/positron#13067](https://github.com/posit-dev/positron/pull/13067)) so the Packages pane can show the "update available" up-arrow next to outdated Julia packages.