### PR TITLE
Debug environments & Testitems

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 - **Help Integration** — View Julia documentation inline via Positron's Help pane.
 - **Plots** — Julia plots are captured and displayed in Positron's Plots pane.
 - **Package Pane** — Browse and manage Julia packages directly within Positron.
+- **TestItem Compatible** - Uses the same testing system as `julia-vscode`
+- **Debugger** - Use breakpoints, inspect local and global variables, etc. 
 
 ## Requirements
 

--- a/scripts/apps/testitemcontroller_main.jl
+++ b/scripts/apps/testitemcontroller_main.jl
@@ -23,7 +23,7 @@ try
 
     using TestItemControllers
 
-    controller = JSONRPCTestItemController(conn_in, conn_out)
+    controller = JSONRPCTestItemController(conn_in, conn_out, nothing)
     run(controller)
 catch err
     @error "Test Item Controller crashed" exception=(err, catch_backtrace())

--- a/scripts/packages/TestItemControllers/src/jsonrpctestitemcontroller.jl
+++ b/scripts/packages/TestItemControllers/src/jsonrpctestitemcontroller.jl
@@ -1,4 +1,4 @@
-mutable struct JSONRPCTestItemController{ERR_HANDLER<:Function}
+mutable struct JSONRPCTestItemController{ERR_HANDLER<:Union{Nothing,Function}}
     err_handler::Union{Nothing,ERR_HANDLER}
     endpoint::JSONRPC.JSONRPCEndpoint
     controller::TestItemController

--- a/scripts/packages/TestItemControllers/src/testitemcontroller.jl
+++ b/scripts/packages/TestItemControllers/src/testitemcontroller.jl
@@ -6,7 +6,7 @@ mutable struct TestProcess
     # status::Symbol
 end
 
-mutable struct TestItemController{ERR_HANDLER<:Function}
+mutable struct TestItemController{ERR_HANDLER<:Union{Nothing,Function}}
     err_handler::Union{Nothing,ERR_HANDLER}
 
     msg_channel::Channel

--- a/src/debugger/debugFeature.ts
+++ b/src/debugger/debugFeature.ts
@@ -91,8 +91,16 @@ class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
 					'',  // crash reporting pipe (unused in positron-julia)
 				];
 
+				const positronJuliaConfig = vscode.workspace.getConfiguration('positron.julia');
+				const envPath =
+					positronJuliaConfig.get<string>('languageServer.environmentPath') ||
+					vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				const spawnEnv = envPath
+					? { ...process.env, JULIA_PROJECT: envPath }
+					: process.env;
+
 				LOGGER.info(`Spawning Julia debugger: ${installation.binpath} ${jlArgs.join(' ')}`);
-				const proc = spawn(installation.binpath, jlArgs, { detached: false });
+				const proc = spawn(installation.binpath, jlArgs, { detached: false, env: spawnEnv });
 				proc.on('error', (err) => {
 					server.close();
 					reject(new Error(`Failed to spawn Julia debugger: ${err.message}`));

--- a/src/testing/testFeature.ts
+++ b/src/testing/testFeature.ts
@@ -194,12 +194,16 @@ export class JuliaTestController {
 
         this.connection.listen();
         this.process.stderr.on('data', d => this.outputChannel.append(String(d)));
-        this.process.on('exit', () => {
+        this.process.on('exit', (code) => {
+            const hadActiveRuns = this.testRuns.size > 0;
             this.process = undefined;
             if (this.connection) { this.connection.dispose(); this.connection = null; }
             this._onKilled.fire();
             for (const r of this.testRuns.values()) { r.testRun.end(); }
             this.testFeature.testControllerTerminated();
+            if (hadActiveRuns) {
+                this.outputChannel.show(true);
+            }
         });
         this.process.on('error', err => LOGGER.error(`Julia test controller error: ${err.message}`));
         return false;
@@ -546,7 +550,14 @@ export class TestFeature implements vscode.Disposable {
 
         if (token.isCancellationRequested) { testRun.end(); return; }
 
-        await this.juliaTestController!.createTestRun(testRun, coverageMode, maxProcessCount, allTests, allSetups);
+        try {
+            await this.juliaTestController!.createTestRun(testRun, coverageMode, maxProcessCount, allTests, allSetups);
+        } catch (err) {
+            this.controllerOutputChannel.show(true);
+            vscode.window.showErrorMessage(
+                `Julia test controller exited unexpectedly. Check the "Julia Test Item Controller" output for details.`
+            );
+        }
     }
 
     private _fallbackTestEnv(uriStr: string): tlsp.GetTestEnvRequestParamsReturn {


### PR DESCRIPTION
Test Items were crashing on startup without informative error messages, and debugger wasn't respecting the user's julia environment, leading to errors when packages were loaded. This fixes both of these issues