### PR TITLE
Add convert_to_code functionality for Data Explorer

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,4 +5,7 @@ tsconfig.json
 typings/**
 .github/**
 MIGRATION.md
-!node_modules/**
+node_modules/**
+*.vsix
+README_files/**
+.code-review-graph/**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 - **Runtime Completions** — Supplements LSP completions with live variables and functions from the running Julia session via the Jupyter `complete_request` protocol.
 - **Run Multiline Statements** — Press `Ctrl+Enter` / `Cmd+Enter` to send the full multiline statement at the cursor (functions, loops, blocks) to the console. Handles `function…end`, `if…end`, unclosed brackets, pipe chains, and more.
 - **Semantic Highlighting** — Enhanced syntax highlighting with semantic information from the Language Server for accurate color coding of functions, types, modules, and other language constructs.
-- **Data Explorer** — Open DataFrames, matrices, and other tabular data in Positron's interactive Data Explorer with sorting, filtering, and summary statistics.
+- **Data Explorer** — Open DataFrames, matrices, and other tabular data in Positron's interactive Data Explorer with sorting, filtering, and summary statistics. Convert the current state of the Data Explorer into to Code
 - **Variables Pane** — Browse all session variables with type and value summaries.
 - **Help Integration** — View Julia documentation inline via Positron's Help pane.
 - **Plots** — Julia plots are captured and displayed in Positron's Plots pane.

--- a/julia/Positron/src/data_explorer.jl
+++ b/julia/Positron/src/data_explorer.jl
@@ -131,6 +131,8 @@ function handle_data_explorer_msg(instance::DataExplorerInstance, msg::Dict)
             handle_get_column_profiles(instance, request)
         elseif request isa DataExplorerExportDataSelectionParams
             handle_export_data_selection(instance, request)
+        elseif request isa DataExplorerConvertToCodeParams
+            handle_convert_to_code(instance, request)
         end
     end
 end
@@ -454,6 +456,19 @@ function handle_export_data_selection(
     result = ExportedData(data_str, request.format)
     send_result(instance.comm, result)
 end
+
+"""
+Handle convert_to_code request.
+"""
+function handle_convert_to_code(
+    instance::DataExplorerInstance,
+    request::DataExplorerConvertToCodeParams,
+)
+    code = convert_to_code(instance.data, instance.display_name, request)
+    result = ConvertedCode(code)
+    send_result(instance.comm, result)
+end
+
 
 # -------------------------------------------------------------------------
 # Data Access Functions (to be specialized for different table types)
@@ -1493,6 +1508,283 @@ function export_selection(
 end
 
 """
+Format a value for code output.
+"""
+function format_code_val(val::String, type_display::ColumnDisplayType)::String
+    if type_display in (ColumnDisplayType_Integer, ColumnDisplayType_Floating)
+        # Try to parse as number to verify it is valid numeric literal
+        parsed = tryparse(Float64, val)
+        if parsed !== nothing
+            return val
+        end
+    elseif type_display == ColumnDisplayType_Boolean
+        if lowercase(val) == "true"
+            return "true"
+        elseif lowercase(val) == "false"
+            return "false"
+        end
+    end
+    # Default is a quoted string
+    escaped = escape_string(val)
+    return "\"$escaped\""
+end
+
+"""
+Convert a RowFilter to a TidierData condition string.
+"""
+function to_tidier_cond(f::RowFilter)::String
+    col = f.column_schema.column_name
+    type_display = f.column_schema.type_display
+    
+    if f.filter_type == RowFilterType_IsNull
+        return "ismissing($col)"
+    elseif f.filter_type == RowFilterType_NotNull
+        return "!ismissing($col)"
+    elseif f.filter_type == RowFilterType_IsEmpty
+        return "ismissing($col) || $col == \"\""
+    elseif f.filter_type == RowFilterType_NotEmpty
+        return "!ismissing($col) && $col != \"\""
+    elseif f.filter_type == RowFilterType_IsTrue
+        return "$col == true"
+    elseif f.filter_type == RowFilterType_IsFalse
+        return "$col == false"
+    end
+    
+    params = f.params
+    if params === nothing
+        return "true"
+    end
+    
+    if params isa FilterComparison
+        # Map op
+        op_str = string(params.op)
+        if op_str == "="
+            op_str = "=="
+        end
+        val_str = format_code_val(params.value, type_display)
+        return "$col $op_str $val_str"
+    elseif params isa FilterBetween
+        left = format_code_val(params.left_value, type_display)
+        right = format_code_val(params.right_value, type_display)
+        if f.filter_type == RowFilterType_NotBetween
+            return "$col < $left || $col > $right"
+        else
+            return "$col >= $left && $col <= $right"
+        end
+    elseif params isa FilterTextSearch
+        term_escaped = escape_string(params.term)
+        term_str = "\"$term_escaped\""
+        if params.search_type == TextSearchType_Contains
+            if params.case_sensitive
+                return "occursin($term_str, $col)"
+            else
+                return "occursin(lowercase($term_str), lowercase($col))"
+            end
+        elseif params.search_type == TextSearchType_NotContains
+            if params.case_sensitive
+                return "!occursin($term_str, $col)"
+            else
+                return "!occursin(lowercase($term_str), lowercase($col))"
+            end
+        elseif params.search_type == TextSearchType_StartsWith
+            if params.case_sensitive
+                return "startswith($col, $term_str)"
+            else
+                return "startswith(lowercase($col), lowercase($term_str))"
+            end
+        elseif params.search_type == TextSearchType_EndsWith
+            if params.case_sensitive
+                return "endswith($col, $term_str)"
+            else
+                return "endswith(lowercase($col), lowercase($term_str))"
+            end
+        elseif params.search_type == TextSearchType_RegexMatch
+            flags = params.case_sensitive ? "" : "i"
+            return "occursin(Regex($term_str, \"$flags\"), $col)"
+        end
+    elseif params isa FilterSetMembership
+        items = [format_code_val(v, type_display) for v in params.values]
+        items_str = "[" * join(items, ", ") * "]"
+        if params.inclusive
+            return "$col in $items_str"
+        else
+            return "!($col in $items_str)"
+        end
+    end
+    
+    return "true"
+end
+
+"""
+Convert active filters to reproducible TidierData.jl code.
+"""
+function convert_to_code_tidier(
+    data::Any,
+    display_name::String,
+    request::DataExplorerConvertToCodeParams,
+)::Vector{String}
+    code_lines = String[]
+    push!(code_lines, "using TidierData")
+    push!(code_lines, "")
+    
+    chain_parts = String[]
+    
+    # 1. Row Filters
+    if !isempty(request.row_filters)
+        filter_expr = ""
+        for (i, f) in enumerate(request.row_filters)
+            cond = to_tidier_cond(f)
+            if i == 1
+                filter_expr = cond
+            else
+                op = f.condition == RowFilterCondition_Or ? "||" : "&&"
+                filter_expr = "$filter_expr $op $cond"
+            end
+        end
+        push!(chain_parts, "    @filter($filter_expr)")
+    end
+    
+    # 2. Column Selections (using column_filters)
+    if !isempty(request.column_filters)
+        ncols = get_num_columns(data)
+        matched_cols = String[]
+        for col_idx in 1:ncols
+            schema = get_column_schema(data, col_idx)
+            if matches_column_filters(schema, request.column_filters)
+                push!(matched_cols, schema.column_name)
+            end
+        end
+        if length(matched_cols) < ncols
+            select_args = join(matched_cols, ", ")
+            push!(chain_parts, "    @select($select_args)")
+        end
+    end
+    
+    # 3. Sort Keys
+    if !isempty(request.sort_keys)
+        arrange_args = String[]
+        for key in request.sort_keys
+            col_name = get_column_name(data, key.column_index + 1)
+            if key.ascending
+                push!(arrange_args, col_name)
+            else
+                push!(arrange_args, "desc($col_name)")
+            end
+        end
+        arrange_str = join(arrange_args, ", ")
+        push!(chain_parts, "    @arrange($arrange_str)")
+    end
+    
+    # Assemble the chain code
+    if isempty(chain_parts)
+        push!(code_lines, display_name)
+    else
+        push!(code_lines, "result = @chain $display_name begin")
+        append!(code_lines, chain_parts)
+        push!(code_lines, "end")
+    end
+    
+    return code_lines
+end
+
+"""
+Convert active filters to reproducible DataFrames.jl code.
+"""
+function convert_to_code_dataframes(
+    data::Any,
+    display_name::String,
+    request::DataExplorerConvertToCodeParams,
+)::Vector{String}
+    code_lines = String[]
+    push!(code_lines, "using DataFrames")
+    push!(code_lines, "")
+    
+    pipe_parts = String[]
+    push!(pipe_parts, display_name)
+    
+    # 1. Row Filters
+    if !isempty(request.row_filters)
+        cols_needed = unique([Symbol(f.column_schema.column_name) for f in request.row_filters])
+        cols_arg = length(cols_needed) == 1 ? ":$(cols_needed[1])" : "[" * join([":$c" for c in cols_needed], ", ") * "]"
+        lambda_args = join([string(c) for c in cols_needed], ", ")
+        if length(cols_needed) > 1
+            lambda_args = "($lambda_args)"
+        end
+        filter_expr = ""
+        for (i, f) in enumerate(request.row_filters)
+            cond = to_tidier_cond(f)
+            if i == 1
+                filter_expr = cond
+            else
+                op = f.condition == RowFilterCondition_Or ? "||" : "&&"
+                filter_expr = "$filter_expr $op $cond"
+            end
+        end
+        push!(pipe_parts, "    x -> subset(x, $cols_arg => ByRow($lambda_args -> $filter_expr))")
+    end
+    
+    # 2. Column Selections (using column_filters)
+    if !isempty(request.column_filters)
+        ncols = get_num_columns(data)
+        matched_cols = String[]
+        for col_idx in 1:ncols
+            schema = get_column_schema(data, col_idx)
+            if matches_column_filters(schema, request.column_filters)
+                push!(matched_cols, schema.column_name)
+            end
+        end
+        if length(matched_cols) < ncols
+            select_args = "[" * join([":$c" for c in matched_cols], ", ") * "]"
+            push!(pipe_parts, "    x -> select(x, $select_args)")
+        end
+    end
+    
+    # 3. Sort Keys
+    if !isempty(request.sort_keys)
+        sort_cols = String[]
+        sort_revs = String[]
+        for key in request.sort_keys
+            col_name = get_column_name(data, key.column_index + 1)
+            push!(sort_cols, ":$col_name")
+            push!(sort_revs, string(!key.ascending))
+        end
+        cols_arg = length(sort_cols) == 1 ? sort_cols[1] : "[" * join(sort_cols, ", ") * "]"
+        rev_arg = length(sort_revs) == 1 ? "rev=$(sort_revs[1])" : "rev=[" * join(sort_revs, ", ") * "]"
+        push!(pipe_parts, "    x -> sort(x, $cols_arg, $rev_arg)")
+    end
+    
+    if length(pipe_parts) == 1
+        push!(code_lines, pipe_parts[1])
+    else
+        push!(code_lines, "result = " * pipe_parts[1] * " |>")
+        for i in 2:(length(pipe_parts) - 1)
+            push!(code_lines, pipe_parts[i] * " |>")
+        end
+        push!(code_lines, pipe_parts[end])
+    end
+    
+    return code_lines
+end
+
+"""
+Generate reproducible Julia code from the current Data Explorer state.
+"""
+function convert_to_code(
+    data::Any,
+    display_name::String,
+    request::DataExplorerConvertToCodeParams,
+)::Vector{String}
+    syntax = request.code_syntax_name.code_syntax_name
+    if lowercase(syntax) == "tidierdata"
+        return convert_to_code_tidier(data, display_name, request)
+    else
+        # Default to DataFrames
+        return convert_to_code_dataframes(data, display_name, request)
+    end
+end
+
+
+"""
 Get supported features for the data explorer.
 """
 function get_supported_features()::SupportedFeatures
@@ -1560,7 +1852,13 @@ function get_supported_features()::SupportedFeatures
             SupportStatus_Supported,
             [ExportFormat_Csv, ExportFormat_Tsv],
         ),
-        ConvertToCodeFeatures(SupportStatus_Unsupported, nothing),
+        ConvertToCodeFeatures(
+            SupportStatus_Supported,
+            [
+                CodeSyntaxName("DataFrames"),
+                CodeSyntaxName("TidierData"),
+            ],
+        ),
     )
 end
 

--- a/julia/Positron/src/data_explorer.jl
+++ b/julia/Positron/src/data_explorer.jl
@@ -592,7 +592,7 @@ end
 Convert Julia type to display type.
 """
 function julia_type_to_display_type(T::Type)::ColumnDisplayType
-    T = nonmissingtype(T)
+    T = Base.nonmissingtype(T)
     if T <: Bool
         return ColumnDisplayType_Boolean
     elseif T <: AbstractString
@@ -1532,7 +1532,18 @@ end
 
 # Returns true if name can be used as a bare Julia identifier (not a keyword).
 function is_safe_identifier(name::String)::Bool
-    return Base.isidentifier(name) && !Base.iskeyword(name)
+    if !Base.isidentifier(name)
+        return false
+    end
+    # Base.isidentifier accepts reserved words ("function", "end", "true", ...),
+    # which cannot be used as bare identifiers. Reject anything that does not
+    # round-trip through the parser as a plain Symbol.
+    parsed = try
+        Meta.parse(name)
+    catch
+        return false
+    end
+    return parsed isa Symbol && string(parsed) == name
 end
 
 # Returns a TidierData-safe column reference: bare name or var"..." for non-identifiers.

--- a/julia/Positron/src/data_explorer.jl
+++ b/julia/Positron/src/data_explorer.jl
@@ -592,6 +592,7 @@ end
 Convert Julia type to display type.
 """
 function julia_type_to_display_type(T::Type)::ColumnDisplayType
+    T = nonmissingtype(T)
     if T <: Bool
         return ColumnDisplayType_Boolean
     elseif T <: AbstractString
@@ -843,7 +844,7 @@ function apply_row_filters(
 
     for filter in filters
         filter_mask = apply_single_row_filter(data, filter)
-        if filter.condition == "and"
+        if filter.condition == RowFilterCondition_And
             mask .&= filter_mask
         else  # "or"
             mask .|= filter_mask
@@ -893,17 +894,17 @@ function apply_single_row_filter(data::Any, filter::RowFilter)::BitVector
         compare_val = tryparse(Float64, filter.params.value)
         if compare_val !== nothing
             # Vectorized numeric comparison
-            if filter.params.op == "="
+            if filter.params.op == FilterComparisonOp_Eq
                 return col .== compare_val
-            elseif filter.params.op == "!="
+            elseif filter.params.op == FilterComparisonOp_NotEq
                 return col .!= compare_val
-            elseif filter.params.op == "<"
+            elseif filter.params.op == FilterComparisonOp_Lt
                 return col .< compare_val
-            elseif filter.params.op == "<="
+            elseif filter.params.op == FilterComparisonOp_LtEq
                 return col .<= compare_val
-            elseif filter.params.op == ">"
+            elseif filter.params.op == FilterComparisonOp_Gt
                 return col .> compare_val
-            elseif filter.params.op == ">="
+            elseif filter.params.op == FilterComparisonOp_GtEq
                 return col .>= compare_val
             end
         end
@@ -983,7 +984,7 @@ end
 """
 Apply comparison filter.
 """
-function apply_comparison(val::Any, op::String, compare_val::String)::Bool
+function apply_comparison(val::Any, op::FilterComparisonOp, compare_val::String)::Bool
     if val === nothing || val === missing
         return false
     end
@@ -996,17 +997,17 @@ function apply_comparison(val::Any, op::String, compare_val::String)::Bool
             compare = compare_val
         end
 
-        if op == "="
+        if op == FilterComparisonOp_Eq
             return val == compare
-        elseif op == "!="
+        elseif op == FilterComparisonOp_NotEq
             return val != compare
-        elseif op == "<"
+        elseif op == FilterComparisonOp_Lt
             return val < compare
-        elseif op == "<="
+        elseif op == FilterComparisonOp_LtEq
             return val <= compare
-        elseif op == ">"
+        elseif op == FilterComparisonOp_Gt
             return val > compare
-        elseif op == ">="
+        elseif op == FilterComparisonOp_GtEq
             return val >= compare
         end
     catch
@@ -1529,90 +1530,131 @@ function format_code_val(val::String, type_display::ColumnDisplayType)::String
     return "\"$escaped\""
 end
 
+# Returns true if name can be used as a bare Julia identifier (not a keyword).
+function is_safe_identifier(name::String)::Bool
+    return Base.isidentifier(name) && !Base.iskeyword(name)
+end
+
+# Returns a TidierData-safe column reference: bare name or var"..." for non-identifiers.
+function tidier_col_ref(name::String)::String
+    if is_safe_identifier(name)
+        return name
+    else
+        return "var\"$(escape_string(name))\""
+    end
+end
+
+# Returns a DataFrames-safe column selector: :name or Symbol("name") for non-identifiers.
+function df_col_selector(name::String)::String
+    if is_safe_identifier(name)
+        return ":$name"
+    else
+        return "Symbol(\"$(escape_string(name))\")"
+    end
+end
+
+# Returns a safe Julia variable name for a DataFrames lambda argument.
+function safe_var_name(name::String, idx::Int)::String
+    if is_safe_identifier(name)
+        return name
+    else
+        return "_col$idx"
+    end
+end
+
 """
-Convert a RowFilter to a TidierData condition string.
+Convert a RowFilter to a condition string, using col_ref as the identifier for the column value.
 """
-function to_tidier_cond(f::RowFilter)::String
-    col = f.column_schema.column_name
+function to_code_cond(f::RowFilter, col_ref::String)::String
     type_display = f.column_schema.type_display
     
     if f.filter_type == RowFilterType_IsNull
-        return "ismissing($col)"
+        return "ismissing($col_ref)"
     elseif f.filter_type == RowFilterType_NotNull
-        return "!ismissing($col)"
+        return "!ismissing($col_ref)"
     elseif f.filter_type == RowFilterType_IsEmpty
-        return "ismissing($col) || $col == \"\""
+        return "ismissing($col_ref) || $col_ref == \"\""
     elseif f.filter_type == RowFilterType_NotEmpty
-        return "!ismissing($col) && $col != \"\""
+        return "!ismissing($col_ref) && $col_ref != \"\""
     elseif f.filter_type == RowFilterType_IsTrue
-        return "$col == true"
+        return "$col_ref == true"
     elseif f.filter_type == RowFilterType_IsFalse
-        return "$col == false"
+        return "$col_ref == false"
     end
-    
+
     params = f.params
     if params === nothing
         return "true"
     end
-    
+
     if params isa FilterComparison
-        # Map op
         op_str = string(params.op)
         if op_str == "="
             op_str = "=="
         end
         val_str = format_code_val(params.value, type_display)
-        return "$col $op_str $val_str"
+        return "$col_ref $op_str $val_str"
     elseif params isa FilterBetween
         left = format_code_val(params.left_value, type_display)
         right = format_code_val(params.right_value, type_display)
         if f.filter_type == RowFilterType_NotBetween
-            return "$col < $left || $col > $right"
+            return "$col_ref < $left || $col_ref > $right"
         else
-            return "$col >= $left && $col <= $right"
+            return "$col_ref >= $left && $col_ref <= $right"
         end
     elseif params isa FilterTextSearch
         term_escaped = escape_string(params.term)
         term_str = "\"$term_escaped\""
+        # Guard missing values; stringify so the filter works on non-string columns,
+        # matching the runtime's string(val) conversion.
+        guard = "!ismissing($col_ref)"
+        str_ref = "string($col_ref)"
         if params.search_type == TextSearchType_Contains
             if params.case_sensitive
-                return "occursin($term_str, $col)"
+                return "$guard && occursin($term_str, $str_ref)"
             else
-                return "occursin(lowercase($term_str), lowercase($col))"
+                return "$guard && occursin(lowercase($term_str), lowercase($str_ref))"
             end
         elseif params.search_type == TextSearchType_NotContains
             if params.case_sensitive
-                return "!occursin($term_str, $col)"
+                return "$guard && !occursin($term_str, $str_ref)"
             else
-                return "!occursin(lowercase($term_str), lowercase($col))"
+                return "$guard && !occursin(lowercase($term_str), lowercase($str_ref))"
             end
         elseif params.search_type == TextSearchType_StartsWith
             if params.case_sensitive
-                return "startswith($col, $term_str)"
+                return "$guard && startswith($str_ref, $term_str)"
             else
-                return "startswith(lowercase($col), lowercase($term_str))"
+                return "$guard && startswith(lowercase($str_ref), lowercase($term_str))"
             end
         elseif params.search_type == TextSearchType_EndsWith
             if params.case_sensitive
-                return "endswith($col, $term_str)"
+                return "$guard && endswith($str_ref, $term_str)"
             else
-                return "endswith(lowercase($col), lowercase($term_str))"
+                return "$guard && endswith(lowercase($str_ref), lowercase($term_str))"
             end
         elseif params.search_type == TextSearchType_RegexMatch
             flags = params.case_sensitive ? "" : "i"
-            return "occursin(Regex($term_str, \"$flags\"), $col)"
+            return "$guard && occursin(Regex($term_str, \"$flags\"), $str_ref)"
         end
     elseif params isa FilterSetMembership
         items = [format_code_val(v, type_display) for v in params.values]
         items_str = "[" * join(items, ", ") * "]"
         if params.inclusive
-            return "$col in $items_str"
+            return "$col_ref in $items_str"
         else
-            return "!($col in $items_str)"
+            return "!($col_ref in $items_str)"
         end
     end
-    
+
     return "true"
+end
+
+"""
+Convert a RowFilter to a TidierData condition string.
+"""
+function to_tidier_cond(f::RowFilter)::String
+    return to_code_cond(f, tidier_col_ref(f.column_schema.column_name))
 end
 
 """
@@ -1655,20 +1697,21 @@ function convert_to_code_tidier(
             end
         end
         if length(matched_cols) < ncols
-            select_args = join(matched_cols, ", ")
+            select_args = join([tidier_col_ref(c) for c in matched_cols], ", ")
             push!(chain_parts, "    @select($select_args)")
         end
     end
-    
+
     # 3. Sort Keys
     if !isempty(request.sort_keys)
         arrange_args = String[]
         for key in request.sort_keys
             col_name = get_column_name(data, key.column_index + 1)
+            ref = tidier_col_ref(col_name)
             if key.ascending
-                push!(arrange_args, col_name)
+                push!(arrange_args, ref)
             else
-                push!(arrange_args, "desc($col_name)")
+                push!(arrange_args, "desc($ref)")
             end
         end
         arrange_str = join(arrange_args, ", ")
@@ -1704,15 +1747,19 @@ function convert_to_code_dataframes(
     
     # 1. Row Filters
     if !isempty(request.row_filters)
-        cols_needed = unique([Symbol(f.column_schema.column_name) for f in request.row_filters])
-        cols_arg = length(cols_needed) == 1 ? ":$(cols_needed[1])" : "[" * join([":$c" for c in cols_needed], ", ") * "]"
-        lambda_args = join([string(c) for c in cols_needed], ", ")
-        if length(cols_needed) > 1
-            lambda_args = "($lambda_args)"
+        col_names_needed = unique([f.column_schema.column_name for f in request.row_filters])
+        # Map each column name to a safe lambda argument name
+        col_to_arg = Dict(name => safe_var_name(name, i) for (i, name) in enumerate(col_names_needed))
+        cols_arg = if length(col_names_needed) == 1
+            df_col_selector(col_names_needed[1])
+        else
+            "[" * join([df_col_selector(c) for c in col_names_needed], ", ") * "]"
         end
+        arg_names = [col_to_arg[name] for name in col_names_needed]
+        lambda_args = length(arg_names) == 1 ? arg_names[1] : "(" * join(arg_names, ", ") * ")"
         filter_expr = ""
         for (i, f) in enumerate(request.row_filters)
-            cond = to_tidier_cond(f)
+            cond = to_code_cond(f, col_to_arg[f.column_schema.column_name])
             if i == 1
                 filter_expr = cond
             else
@@ -1720,9 +1767,10 @@ function convert_to_code_dataframes(
                 filter_expr = "$filter_expr $op $cond"
             end
         end
-        push!(pipe_parts, "    x -> subset(x, $cols_arg => ByRow($lambda_args -> $filter_expr))")
+        # skipmissing=true matches the Data Explorer behavior of treating missing as non-match
+        push!(pipe_parts, "    x -> subset(x, $cols_arg => ByRow($lambda_args -> $filter_expr), skipmissing=true)")
     end
-    
+
     # 2. Column Selections (using column_filters)
     if !isempty(request.column_filters)
         ncols = get_num_columns(data)
@@ -1734,18 +1782,18 @@ function convert_to_code_dataframes(
             end
         end
         if length(matched_cols) < ncols
-            select_args = "[" * join([":$c" for c in matched_cols], ", ") * "]"
+            select_args = "[" * join([df_col_selector(c) for c in matched_cols], ", ") * "]"
             push!(pipe_parts, "    x -> select(x, $select_args)")
         end
     end
-    
+
     # 3. Sort Keys
     if !isempty(request.sort_keys)
         sort_cols = String[]
         sort_revs = String[]
         for key in request.sort_keys
             col_name = get_column_name(data, key.column_index + 1)
-            push!(sort_cols, ":$col_name")
+            push!(sort_cols, df_col_selector(col_name))
             push!(sort_revs, string(!key.ascending))
         end
         cols_arg = length(sort_cols) == 1 ? sort_cols[1] : "[" * join(sort_cols, ", ") * "]"

--- a/julia/Positron/src/data_explorer_comm.jl
+++ b/julia/Positron/src/data_explorer_comm.jl
@@ -1329,6 +1329,41 @@ function parse_column_sort_key(data::Dict)::ColumnSortKey
 end
 
 """
+Parse FilterMatchDataTypes from a Dict.
+"""
+function parse_filter_match_data_types(data::Dict)::FilterMatchDataTypes
+    types_list = get(data, "display_types", [])
+    display_types = [STRING_TO_COLUMNDISPLAYTYPE[t] for t in types_list]
+    return FilterMatchDataTypes(display_types)
+end
+
+"""
+Parse ColumnFilter from a Dict.
+"""
+function parse_column_filter(data::Dict)::ColumnFilter
+    filter_type_str = get(data, "filter_type", "text_search")
+    filter_type = STRING_TO_COLUMNFILTERTYPE[filter_type_str]
+
+    params_data = get(data, "params", Dict())
+    params = if filter_type == ColumnFilterType_TextSearch
+        parse_filter_text_search(params_data)
+    elseif filter_type == ColumnFilterType_MatchDataTypes
+        parse_filter_match_data_types(params_data)
+    else
+        error("Unknown ColumnFilterType: $filter_type")
+    end
+
+    return ColumnFilter(filter_type, params)
+end
+
+"""
+Parse CodeSyntaxName from a Dict.
+"""
+function parse_code_syntax_name(data::Dict)::CodeSyntaxName
+    return CodeSyntaxName(get(data, "code_syntax_name", ""))
+end
+
+"""
 Parse a backend request for the DataExplorer comm.
 """
 function parse_data_explorer_request(data::Dict)
@@ -1367,11 +1402,19 @@ function parse_data_explorer_request(data::Dict)
             STRING_TO_EXPORTFORMAT[format_str],
         )
     elseif method == "convert_to_code"
+        col_filters_dicts = get(params, "column_filters", [])
+        col_filters = [parse_column_filter(f) for f in col_filters_dicts]
+        row_filters_dicts = get(params, "row_filters", [])
+        row_filters = [parse_row_filter(f) for f in row_filters_dicts]
+        sort_keys_dicts = get(params, "sort_keys", [])
+        sort_keys = [parse_column_sort_key(k) for k in sort_keys_dicts]
+        code_syntax_name_dict = get(params, "code_syntax_name", Dict())
+        code_syntax_name = parse_code_syntax_name(code_syntax_name_dict)
         return DataExplorerConvertToCodeParams(
-            get(params, "column_filters", []),
-            get(params, "row_filters", []),
-            get(params, "sort_keys", []),
-            get(params, "code_syntax_name", Dict()),
+            col_filters,
+            row_filters,
+            sort_keys,
+            code_syntax_name,
         )
     elseif method == "suggest_code_syntax"
         return nothing

--- a/julia/Positron/test/test_data_explorer.jl
+++ b/julia/Positron/test/test_data_explorer.jl
@@ -2152,4 +2152,94 @@ end
         @test result.sort_keys[2].column_index == 2
         @test result.sort_keys[2].ascending == false
     end
+
+    @testset "parse_data_explorer_request - convert_to_code" begin
+        data = Dict(
+            "method" => "convert_to_code",
+            "params" => Dict(
+                "column_filters" => [
+                    Dict(
+                        "filter_type" => "text_search",
+                        "params" => Dict("search_type" => "contains", "term" => "x", "case_sensitive" => false)
+                    )
+                ],
+                "row_filters" => [
+                    Dict(
+                        "filter_id" => "f1",
+                        "filter_type" => "compare",
+                        "column_schema" => Dict(
+                            "column_name" => "age",
+                            "column_index" => 0,
+                            "type_name" => "Int64",
+                            "type_display" => "integer",
+                        ),
+                        "condition" => "and",
+                        "params" => Dict("op" => ">", "value" => "21")
+                    )
+                ],
+                "sort_keys" => [
+                    Dict("column_index" => 1, "ascending" => false)
+                ],
+                "code_syntax_name" => Dict(
+                    "code_syntax_name" => "TidierData"
+                )
+            )
+        )
+        result = Positron.parse_data_explorer_request(data)
+
+        @test result isa Positron.DataExplorerConvertToCodeParams
+        @test length(result.column_filters) == 1
+        @test result.column_filters[1].filter_type == Positron.ColumnFilterType_TextSearch
+        @test length(result.row_filters) == 1
+        @test result.row_filters[1].filter_type == Positron.RowFilterType_Compare
+        @test result.row_filters[1].params isa Positron.FilterComparison
+        @test result.row_filters[1].params.op == Positron.FilterComparisonOp_Gt
+        @test length(result.sort_keys) == 1
+        @test result.sort_keys[1].column_index == 1
+        @test result.sort_keys[1].ascending == false
+        @test result.code_syntax_name.code_syntax_name == "TidierData"
+    end
+
+    @testset "convert_to_code - TidierData and DataFrames" begin
+        df = DataFrame(age = [20, 25, 30], score = [80.5, 90.0, 95.5])
+        
+        row_filter = Positron.RowFilter(
+            "f1",
+            Positron.RowFilterType_Compare,
+            Positron.ColumnSchema("age", nothing, 0, "Int64", Positron.ColumnDisplayType_Integer, nothing, nothing, nothing, nothing, nothing, nothing),
+            Positron.RowFilterCondition_And,
+            true,
+            nothing,
+            Positron.FilterComparison(Positron.FilterComparisonOp_Gt, "21")
+        )
+        
+        sort_key = Positron.ColumnSortKey(1, false) # score descending
+        
+        request_tidier = Positron.DataExplorerConvertToCodeParams(
+            Positron.ColumnFilter[],
+            [row_filter],
+            [sort_key],
+            Positron.CodeSyntaxName("TidierData")
+        )
+        
+        code_tidier = Positron.convert_to_code(df, "my_df", request_tidier)
+        @test "using TidierData" in code_tidier
+        @test any(occursin("@filter(age > 21)", line) for line in code_tidier)
+        @test any(occursin("@arrange(desc(score))", line) for line in code_tidier)
+        @test any(occursin("result = @chain my_df begin", line) for line in code_tidier)
+
+        request_df = Positron.DataExplorerConvertToCodeParams(
+            Positron.ColumnFilter[],
+            [row_filter],
+            [sort_key],
+            Positron.CodeSyntaxName("DataFrames")
+        )
+        
+        code_df = Positron.convert_to_code(df, "my_df", request_df)
+        @test "using DataFrames" in code_df
+        @test any(occursin("subset(x, :age => ByRow(age -> age > 21))", line) for line in code_df)
+        @test any(occursin("sort(x, :score, rev=true)", line) for line in code_df)
+        @test any(occursin("result = my_df |>", line) for line in code_df)
+    end
 end
+

--- a/julia/Positron/test/test_data_explorer.jl
+++ b/julia/Positron/test/test_data_explorer.jl
@@ -2237,7 +2237,7 @@ end
         
         code_df = Positron.convert_to_code(df, "my_df", request_df)
         @test "using DataFrames" in code_df
-        @test any(occursin("subset(x, :age => ByRow(age -> age > 21))", line) for line in code_df)
+        @test any(occursin("subset(x, :age => ByRow(age -> age > 21), skipmissing=true)", line) for line in code_df)
         @test any(occursin("sort(x, :score, rev=true)", line) for line in code_df)
         @test any(occursin("result = my_df |>", line) for line in code_df)
     end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "positron-julia",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "positron-julia",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "semver": "^7.6.3",
@@ -19,6 +19,7 @@
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
         "@vscode/vsce": "^3.3.2",
+        "esbuild": "^0.28.1",
         "eslint": "^8.9.0",
         "typescript": "^4.5.5"
       },
@@ -235,6 +236,448 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2286,6 +2729,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -533,26 +533,28 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run bundle",
+    "bundle": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --external:positron --format=cjs --platform=node --minify",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "lint": "eslint src --ext ts",
     "package": "vsce package",
     "test:julia": "julia --project=./julia/Positron -e \"using Pkg; Pkg.test()\"",
-    "verify": "npm run compile && npm run package"
+    "verify": "npm run bundle && npm run package"
   },
   "devDependencies": {
-    "@types/node": "14.x",
     "@types/glob": "^7.2.0",
+    "@types/node": "14.x",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
+    "@vscode/vsce": "^3.3.2",
+    "esbuild": "^0.28.1",
     "eslint": "^8.9.0",
-    "typescript": "^4.5.5",
-    "@vscode/vsce": "^3.3.2"
+    "typescript": "^4.5.5"
   },
   "dependencies": {
-    "which": "^3.0.0",
     "semver": "^7.6.3",
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "which": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "positron-julia",
   "displayName": "Julia for Positron",
   "description": "Julia language support for Positron IDE",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "publisher": "ntluong95",
   "author": "TidierOrg, rdboyes, ntluong95",
   "contributors": [


### PR DESCRIPTION
Implement parsing logic for various filter types and integrate them into the Data Explorer's request handling for the new `convert_to_code` method. This enhancement allows users to convert data exploration parameters into code snippets.