### PR TITLE
Sync upstream Package Pane detail editor and missing-packages prompt

### DIFF
--- a/julia/Positron/test/test_package_helpers.jl
+++ b/julia/Positron/test/test_package_helpers.jl
@@ -195,4 +195,36 @@ end
         end
         @test strip(missing_json) == "null"
     end
+
+    @testset "Missing Packages Detection" begin
+        read_missing = function (names)
+            json = _capture_package_helper_stdout() do
+                _positron_missing_packages(names)
+            end
+            return JSON3.read(json, Vector{String})
+        end
+
+        # Installed in the test environment -> not missing.
+        @test read_missing(["JSON3"]) == String[]
+
+        # Stdlib: loadable without being a project dependency -> not missing.
+        @test read_missing(["LinearAlgebra"]) == String[]
+
+        # Not in any registry -> never offered, even though not installed.
+        @test read_missing(["ThisPackageDoesNotExist12345"]) == String[]
+
+        # Registered in General but not installed in the test project ->
+        # missing and installable. `Example` is the canonical minimal
+        # registered package and is not a dependency of Positron.jl.
+        @test read_missing(["Example"]) == ["Example"]
+
+        # Mixed list keeps only the missing installable subset.
+        @test read_missing([
+            "JSON3",
+            "LinearAlgebra",
+            "Example",
+            "ThisPackageDoesNotExist12345",
+            "",
+        ]) == ["Example"]
+    end
 end

--- a/julia/Positron/test/test_package_helpers.jl
+++ b/julia/Positron/test/test_package_helpers.jl
@@ -62,6 +62,7 @@ end
             attached = false,
             description = "",
             url = "https://example.com/home",
+            stdlib = false,
         )]
 
         json = _capture_package_helper_stdout() do
@@ -189,11 +190,64 @@ end
         @test haskey(parsed, "version")
         @test occursin(r"^\d+\.\d+", parsed["version"])
         @test parsed["sourceRepository"] == "General"
+        # No license in JSON3's Project.toml; detected from its LICENSE.md.
+        @test parsed["license"] == "MIT"
+        @test occursin("Jacob Quinn", parsed["author"])
+        # Direct deps excluding stdlibs (Parsers, PrecompileTools, ...).
+        @test parsed["dependencyCount"] isa Number
+        @test parsed["dependencyCount"] >= 1
+        @test !haskey(parsed, "stdlib")
 
         missing_json = _capture_package_helper_stdout() do
             _positron_package_detail("ThisPackageDoesNotExist12345")
         end
         @test strip(missing_json) == "null"
+    end
+
+    @testset "Package Detail Stdlib" begin
+        # Dates is a standard library and a dependency of Positron.jl, so it
+        # is visible in Pkg.dependencies() for the test environment.
+        json = _capture_package_helper_stdout() do
+            _positron_package_detail("Dates")
+        end
+
+        parsed = JSON3.read(json, Dict{String, Any})
+        @test parsed["name"] == "Dates"
+        @test parsed["stdlib"] === true
+        @test parsed["license"] == "MIT"
+        @test parsed["sourceRepository"] == "Julia standard library"
+        @test startswith(parsed["url"], "https://docs.julialang.org/")
+        # The one-line title comes from the stdlib's docs/src/index.md.
+        @test haskey(parsed, "title")
+        @test occursin("Dates", parsed["title"])
+    end
+
+    @testset "License Detection" begin
+        @test _positron_detect_license_text("MIT License\nCopyright (c)") == "MIT"
+        @test _positron_detect_license_text(
+            "The X.jl package is licensed under the MIT \"Expat\" License",
+        ) == "MIT"
+        @test _positron_detect_license_text(
+            "Apache License\nVersion 2.0, January 2004",
+        ) == "Apache-2.0"
+        @test _positron_detect_license_text(
+            "GNU GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007",
+        ) == "GPL-3.0"
+        @test _positron_detect_license_text("Some proprietary text") == ""
+
+        empty!(_POSITRON_LICENSE_BY_PATH)
+        mktempdir() do package_dir
+            write(
+                joinpath(package_dir, "LICENSE.md"),
+                "The Example.jl package is licensed under the MIT License.\n",
+            )
+            @test _positron_read_license_file(package_dir) == "MIT"
+        end
+
+        empty!(_POSITRON_LICENSE_BY_PATH)
+        mktempdir() do package_dir
+            @test _positron_read_license_file(package_dir) == ""
+        end
     end
 
     @testset "Missing Packages Detection" begin

--- a/julia/Positron/test/test_package_helpers.jl
+++ b/julia/Positron/test/test_package_helpers.jl
@@ -222,6 +222,71 @@ end
         @test occursin("Dates", parsed["title"])
     end
 
+    @testset "Stdlib Module Docstring" begin
+        # Signature-line variant with a trailing code fence (like Dates).
+        mktempdir() do package_dir
+            mkpath(joinpath(package_dir, "src"))
+            write(
+                joinpath(package_dir, "src", "Example.jl"),
+                """
+                # This file is a part of Julia. License is MIT.
+
+                \"\"\"
+                    Example
+
+                Tools for testing docstring extraction,
+                spanning two lines.
+
+                ```jldoctest
+                julia> 1
+                ```
+                \"\"\"
+                module Example
+                end
+                """,
+            )
+            @test _positron_stdlib_module_docstring(package_dir, "Example") ==
+                "Tools for testing docstring extraction, spanning two lines."
+        end
+
+        # Direct prose variant (like Sockets).
+        mktempdir() do package_dir
+            mkpath(joinpath(package_dir, "src"))
+            write(
+                joinpath(package_dir, "src", "Example.jl"),
+                """
+                \"\"\"
+                Support for examples. Provides [`Example`](@ref).
+                \"\"\"
+                module Example
+                end
+                """,
+            )
+            @test _positron_stdlib_module_docstring(package_dir, "Example") ==
+                "Support for examples. Provides Example."
+        end
+
+        # No module docstring.
+        mktempdir() do package_dir
+            mkpath(joinpath(package_dir, "src"))
+            write(
+                joinpath(package_dir, "src", "Example.jl"),
+                "module Example\nend\n",
+            )
+            @test _positron_stdlib_module_docstring(package_dir, "Example") == ""
+        end
+    end
+
+    @testset "Stdlib List Description" begin
+        # The shared description reader falls back to the module docstring for
+        # stdlibs, so list rows and the detail editor show the same text.
+        empty!(_POSITRON_DESCRIPTION_BY_PATH)
+        dates_path = joinpath(Sys.STDLIB, "Dates")
+        description = _positron_read_package_description(dates_path)
+        @test !isempty(description)
+        @test occursin("Dates", description)
+    end
+
     @testset "License Detection" begin
         @test _positron_detect_license_text("MIT License\nCopyright (c)") == "MIT"
         @test _positron_detect_license_text(

--- a/julia/Positron/test/test_package_helpers.jl
+++ b/julia/Positron/test/test_package_helpers.jl
@@ -145,4 +145,54 @@ end
         parsed = JSON3.read(json, Dict{String, Any})
         @test isempty(parsed)
     end
+
+    @testset "Project Author Parsing" begin
+        empty!(_POSITRON_PROJECT_AUTHOR_BY_PATH)
+
+        mktempdir() do package_dir
+            write(
+                joinpath(package_dir, "Project.toml"),
+                """
+                name = "Example"
+                uuid = "22222222-2222-2222-2222-222222222222"
+                version = "1.0.0"
+                authors = ["Jane Doe <jane@example.com>", "contributors: https://example.com/contributors"]
+                """,
+            )
+
+            @test _positron_read_project_author(package_dir) == "Jane Doe"
+        end
+
+        empty!(_POSITRON_PROJECT_AUTHOR_BY_PATH)
+
+        mktempdir() do package_dir
+            write(
+                joinpath(package_dir, "Project.toml"),
+                """
+                name = "NoAuthors"
+                uuid = "33333333-3333-3333-3333-333333333333"
+                version = "1.0.0"
+                """,
+            )
+
+            @test _positron_read_project_author(package_dir) == ""
+        end
+    end
+
+    @testset "Package Detail" begin
+        json = _capture_package_helper_stdout() do
+            _positron_package_detail("JSON3")
+        end
+
+        parsed = JSON3.read(json, Dict{String, Any})
+        @test parsed["name"] == "JSON3"
+        @test haskey(parsed, "version")
+        @test occursin(r"^\d+\.\d+", parsed["version"])
+        @test parsed["sourceRepository"] == "General"
+
+        missing_json = _capture_package_helper_stdout() do
+            _positron_package_detail("ThisPackageDoesNotExist12345")
+        end
+        @test strip(missing_json) == "null"
+    end
 end

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "positron-julia",
   "displayName": "Julia for Positron",
   "description": "Julia language support for Positron IDE",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "ntluong95",
   "author": "TidierOrg, rdboyes, ntluong95",
   "contributors": [

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -577,6 +577,39 @@ function _positron_package_metadata(names::Vector{String})
 end
 
 """
+Given top-level module/package names referenced in user code, print the JSON
+array of names that are (a) not currently loadable via `Base.identify_package`
+(i.e. not a stdlib and not a dependency of the active project) AND (b) present
+by exact name in a reachable registry (i.e. actually installable). Matches the
+"referenced, not installed, installable" contract of Positron's
+listMissingPackages hook: never offer to install an unresolvable name.
+"""
+function _positron_missing_packages(names::Vector{String})
+    candidates = Set{String}()
+    for raw in names
+        cleaned = String(strip(raw))
+        isempty(cleaned) && continue
+        # Loadable already (stdlib or active-project dep) -> not missing.
+        Base.identify_package(cleaned) === nothing || continue
+        push!(candidates, cleaned)
+    end
+
+    installable = String[]
+    if !isempty(candidates)
+        for registry in Pkg.Registry.reachable_registries()
+            for entry in values(registry.pkgs)
+                entry.name in candidates || continue
+                push!(installable, entry.name)
+                delete!(candidates, entry.name)
+            end
+            isempty(candidates) && break
+        end
+    end
+
+    _positron_print_json_string_array(sort!(installable))
+end
+
+"""
 Look up the installed dependency named `name` (case-insensitive exact match)
 in `Pkg.dependencies()`. Returns `nothing` when the package is not installed.
 """

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -204,7 +204,22 @@ function _positron_read_package_description(package_path)
     isempty(package_path) && return ""
     return get!(_POSITRON_DESCRIPTION_BY_PATH, package_path) do
         description, _, _ = _positron_read_project_metadata(package_path)
-        isempty(description) ? _positron_read_readme_description(package_path) : description
+        isempty(description) || return description
+        description = _positron_read_readme_description(package_path)
+        isempty(description) || return description
+        # Standard libraries have no Project.toml description or README; their
+        # module docstring (and failing that, their manual page) is the only
+        # prose that ships with them. Shared by the list and detail paths so
+        # both show the same text.
+        if _positron_is_stdlib_path(package_path)
+            name = basename(String(package_path))
+            description = _positron_stdlib_module_docstring(package_path, name)
+            isempty(description) || return description
+            return _positron_first_markdown_paragraph(
+                joinpath(package_path, "docs", "src", "index.md"),
+            )
+        end
+        return ""
     end
 end
 
@@ -722,6 +737,77 @@ function _positron_first_markdown_paragraph(path::AbstractString)::String
 end
 
 """
+Extract the first prose paragraph of the module docstring at the top of a
+package's `src/<name>.jl`. Standard library sources open with a triple-quoted
+docstring right above `module <Name>`; some start it with an indented
+signature line (e.g. `    Dates`), which is skipped along with fenced code.
+Returns "" when the file is missing or does not start with a docstring.
+"""
+function _positron_stdlib_module_docstring(
+    package_path::AbstractString,
+    name::AbstractString,
+)::String
+    source_path = joinpath(package_path, "src", "$(name).jl")
+    isfile(source_path) || return ""
+    lines = try
+        collect(Iterators.take(eachline(source_path), 60))
+    catch
+        return ""
+    end
+
+    # Find the opening docstring, skipping comments and blank lines. Any
+    # other code first means there is no module docstring.
+    index = 1
+    while index <= length(lines)
+        line = strip(lines[index])
+        if isempty(line) || startswith(line, "#")
+            index += 1
+        else
+            break
+        end
+    end
+    index > length(lines) && return ""
+    opening = strip(lines[index])
+    startswith(opening, "\"\"\"") || return ""
+
+    # Collect the docstring body until the closing triple quote.
+    body = String[]
+    remainder = strip(opening[4:end])
+    if endswith(remainder, "\"\"\"") && length(remainder) >= 3
+        # One-line docstring: """text"""
+        push!(body, strip(remainder[1:end-3]))
+    else
+        isempty(remainder) || push!(body, remainder)
+        index += 1
+        while index <= length(lines)
+            line = lines[index]
+            occursin("\"\"\"", line) && break
+            push!(body, line)
+            index += 1
+        end
+    end
+
+    # First prose paragraph: skip leading blanks and the indented signature
+    # line; stop at the first blank line or fenced code block.
+    paragraph = String[]
+    for raw in body
+        stripped = strip(raw)
+        startswith(stripped, "```") && break
+        if isempty(paragraph)
+            isempty(stripped) && continue
+            # Indented line before any prose is the signature (e.g. "    Dates").
+            startswith(raw, "    ") && continue
+        elseif isempty(stripped)
+            break
+        end
+        text = _positron_markdown_text(stripped)
+        isempty(text) || push!(paragraph, text)
+    end
+
+    return _positron_collapse_whitespace(join(paragraph, " "))
+end
+
+"""
 Return the first sentence of `text` (through the first period followed by
 whitespace), or the whole text when no sentence boundary is found. Used to
 turn a long docs paragraph into a one-line title.
@@ -880,13 +966,8 @@ function _positron_package_detail(name::String)
     if stdlib
         # Standard libraries ship minimal Project.toml metadata: no authors,
         # license, URL, or registry entry. They are part of Julia itself
-        # (MIT-licensed) and documented in the Julia manual; their only prose
-        # description is the first paragraph of docs/src/index.md.
-        if isempty(description)
-            description = _positron_first_markdown_paragraph(
-                joinpath(package_path, "docs", "src", "index.md"),
-            )
-        end
+        # (MIT-licensed) and documented in the Julia manual; the description
+        # reader falls back to their module docstring / manual page.
         isempty(title) && (title = _positron_first_sentence(description))
         isempty(license) && (license = "MIT")
         isempty(url) && (url = _positron_stdlib_docs_url(package_info.name))

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -27,6 +27,7 @@ const _POSITRON_REGISTRY_URL_BY_NAME = Dict{String, String}()
 # Cache of latest registry version keyed by lowercase package name. Populated
 # during metadata fetches so subsequent calls skip the full registry scan.
 const _POSITRON_REGISTRY_LATEST_VERSION_BY_NAME = Dict{String, String}()
+const _POSITRON_PROJECT_AUTHOR_BY_PATH = Dict{String, String}()
 
 function _positron_json_string(value::AbstractString)::String
     return "\"" * escape_string(value) * "\""
@@ -573,6 +574,104 @@ function _positron_package_metadata(names::Vector{String})
     end
 
     _positron_print_json_metadata(by_name)
+end
+
+"""
+Look up the installed dependency named `name` (case-insensitive exact match)
+in `Pkg.dependencies()`. Returns `nothing` when the package is not installed.
+"""
+function _positron_find_installed_package(name::AbstractString)
+    target = lowercase(strip(String(name)))
+    isempty(target) && return nothing
+    for package_info in values(Pkg.dependencies())
+        lowercase(package_info.name) == target && return package_info
+    end
+    return nothing
+end
+
+"""
+Read and format the `authors` field from Project.toml/JuliaProject.toml for
+display: skips "contributors: ..." entries, strips trailing `<email>`
+addresses, and joins the remaining names with ", ". Returns "" when the
+field is absent or empty.
+"""
+function _positron_read_project_author(package_path)::String
+    package_path isa AbstractString || return ""
+    isempty(package_path) && return ""
+    return get!(_POSITRON_PROJECT_AUTHOR_BY_PATH, String(package_path)) do
+        for filename in ("Project.toml", "JuliaProject.toml")
+            project_path = joinpath(package_path, filename)
+            isfile(project_path) || continue
+            parsed = try
+                TOML.parsefile(project_path)
+            catch err
+                @debug "Failed to parse package author TOML" path=project_path exception=err
+                continue
+            end
+            raw = get(parsed, "authors", nothing)
+            raw isa Vector || return ""
+            author_names = String[]
+            for entry in raw
+                entry isa AbstractString || continue
+                text = strip(entry)
+                isempty(text) && continue
+                occursin(r"^contributors\s*:"i, text) && continue
+                text = strip(replace(text, r"\s*<[^<>]*>\s*$" => ""))
+                isempty(text) || push!(author_names, String(text))
+            end
+            return join(author_names, ", ")
+        end
+        return ""
+    end
+end
+
+"""
+Return the name of the reachable registry (e.g. "General") that contains
+`package_name`, or "" when it is not found in any reachable registry. The
+Julia analog of R's "CRAN" for the detail editor's source repository field.
+"""
+function _positron_registry_name_for_package(package_name::AbstractString)::String
+    target = lowercase(strip(String(package_name)))
+    isempty(target) && return ""
+    for registry in Pkg.Registry.reachable_registries()
+        for entry in values(registry.pkgs)
+            lowercase(entry.name) == target && return registry.name
+        end
+    end
+    return ""
+end
+
+"""
+Print detail fields for a single installed package as one JSON object, or
+`null` when the package is not installed. Called when the package detail
+editor opens; the result is merged over the package's list entry.
+"""
+function _positron_package_detail(name::String)
+    package_info = _positron_find_installed_package(name)
+    if package_info === nothing
+        print("null")
+        return
+    end
+
+    version_val = package_info.version
+    version = version_val === nothing ? "" : string(version_val)
+    package_path = _positron_package_source_path(package_info)
+    description, license, url = _positron_read_project_metadata(package_path)
+    isempty(description) && (description = _positron_read_package_description(package_path))
+    isempty(url) && (url = _positron_package_source_url(package_info))
+    isempty(url) && (url = _positron_registry_package_url(package_info.name))
+    author = _positron_read_project_author(package_path)
+    source_repository = _positron_registry_name_for_package(package_info.name)
+
+    print("{")
+    print("\"name\":", _positron_json_string(package_info.name))
+    isempty(version) || print(",\"version\":", _positron_json_string(version))
+    isempty(author) || print(",\"author\":", _positron_json_string(author))
+    isempty(license) || print(",\"license\":", _positron_json_string(license))
+    isempty(source_repository) || print(",\"sourceRepository\":", _positron_json_string(source_repository))
+    isempty(description) || print(",\"description\":", _positron_json_string(description))
+    isempty(url) || print(",\"url\":", _positron_json_string(url))
+    print("}")
 end
 
 function _positron_search_package_versions(name::String)

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -7,8 +7,8 @@ import Pkg
 import TOML
 
 const _PositronPackage = NamedTuple{
-    (:id, :name, :displayName, :version, :attached, :description, :url),
-    Tuple{String, String, String, String, Bool, String, String},
+    (:id, :name, :displayName, :version, :attached, :description, :url, :stdlib),
+    Tuple{String, String, String, String, Bool, String, String, Bool},
 }
 """
 Canonical ordered list of metadata fields for JSON serialization.
@@ -28,6 +28,7 @@ const _POSITRON_REGISTRY_URL_BY_NAME = Dict{String, String}()
 # during metadata fetches so subsequent calls skip the full registry scan.
 const _POSITRON_REGISTRY_LATEST_VERSION_BY_NAME = Dict{String, String}()
 const _POSITRON_PROJECT_AUTHOR_BY_PATH = Dict{String, String}()
+const _POSITRON_LICENSE_BY_PATH = Dict{String, String}()
 
 function _positron_json_string(value::AbstractString)::String
     return "\"" * escape_string(value) * "\""
@@ -154,6 +155,9 @@ function _positron_print_json_packages(packages)
         end
         if !isempty(package.url)
             print(",\"url\":", _positron_json_string(package.url))
+        end
+        if package.stdlib
+            print(",\"stdlib\":true")
         end
         print("}")
     end
@@ -304,8 +308,15 @@ function _positron_list_packages(direct_only::Bool=true)
         # may have nothing, so guard against string(nothing) == "nothing".
         version_val = package_info.version
         version = version_val === nothing ? "" : string(version_val)
-        description = _positron_read_package_description(_positron_package_source_path(package_info))
+        package_path = _positron_package_source_path(package_info)
+        stdlib = _positron_is_stdlib_path(package_path)
+        description = _positron_read_package_description(package_path)
         url = _positron_package_url(package_info)
+        # Standard library packages are not in any registry; link to their
+        # manual section so the row still gets an external-link button.
+        if stdlib && isempty(url)
+            url = _positron_stdlib_docs_url(name)
+        end
         push!(packages, (
             id = isempty(version) ? name : "$(name)-$(version)",
             name = name,
@@ -314,6 +325,7 @@ function _positron_list_packages(direct_only::Bool=true)
             attached = name in explicitly_loaded,
             description = description,
             url = url,
+            stdlib = stdlib,
         ))
     end
     sort!(packages, by = package -> lowercase(package.name))
@@ -429,6 +441,7 @@ function _positron_search_packages(query::String)
             attached = false,
             description = "",
             url = get(by_url, name, ""),
+            stdlib = false,
         ))
     end
     sort!(packages, by = package -> lowercase(package.name))
@@ -623,6 +636,168 @@ function _positron_find_installed_package(name::AbstractString)
 end
 
 """
+Whether a package source path lives inside Julia's standard library directory.
+Standard library packages ship with Julia, are not in any registry, and carry
+minimal Project.toml metadata, so several detail fields need dedicated
+fallbacks for them.
+"""
+function _positron_is_stdlib_path(package_path)::Bool
+    package_path isa AbstractString || return false
+    isempty(package_path) && return false
+    return startswith(String(package_path), Sys.STDLIB)
+end
+
+"""
+Manual URL for a standard library package, e.g.
+https://docs.julialang.org/en/v1/stdlib/Dates/.
+"""
+function _positron_stdlib_docs_url(name::AbstractString)::String
+    return "https://docs.julialang.org/en/v1/stdlib/$(name)/"
+end
+
+"""
+Set of standard library UUIDs, used to exclude stdlibs from dependency
+counts (mirroring how R's detail RPC excludes base packages). Empty when the
+internal `Pkg.Types.stdlibs` API is unavailable.
+"""
+function _positron_stdlib_uuids()
+    return try
+        Set(keys(Pkg.Types.stdlibs()))
+    catch
+        Set{Base.UUID}()
+    end
+end
+
+"""
+Count a package's direct dependencies, excluding standard libraries.
+"""
+function _positron_dependency_count(package_info)::Int
+    hasproperty(package_info, :dependencies) || return 0
+    deps = package_info.dependencies
+    deps isa AbstractDict || return 0
+    stdlib_uuids = _positron_stdlib_uuids()
+    return count(uuid -> !(uuid in stdlib_uuids), values(deps))
+end
+
+"""
+Extract the first prose paragraph from a markdown file, using the same
+skip rules as the README description reader (headings, fences, badges,
+directive blocks are ignored). Returns "" when the file is missing or has
+no usable paragraph. Used for stdlib docs/src/index.md, which is the only
+prose description that ships with a standard library package.
+"""
+function _positron_first_markdown_paragraph(path::AbstractString)::String
+    isfile(path) || return ""
+    lines = try
+        readlines(path)
+    catch
+        return ""
+    end
+
+    paragraph = String[]
+    in_fence = false
+    for raw in Iterators.take(lines, 160)
+        line = strip(raw)
+        if startswith(line, "```") || startswith(line, "~~~")
+            in_fence = !in_fence
+            continue
+        end
+        in_fence && continue
+
+        if isempty(line)
+            isempty(paragraph) || break
+            continue
+        end
+
+        if _positron_skip_readme_line(line)
+            isempty(paragraph) || break
+            continue
+        end
+
+        text = _positron_markdown_text(line)
+        isempty(text) || push!(paragraph, text)
+    end
+
+    return _positron_collapse_whitespace(join(paragraph, " "))
+end
+
+"""
+Return the first sentence of `text` (through the first period followed by
+whitespace), or the whole text when no sentence boundary is found. Used to
+turn a long docs paragraph into a one-line title.
+"""
+function _positron_first_sentence(text::AbstractString)::String
+    m = match(r"^(.+?\.)\s", text)
+    return m === nothing ? String(text) : String(m.captures[1])
+end
+
+"""
+Detect a license label from license file text. Matches the common license
+families used by Julia packages; returns "" when nothing matches.
+"""
+function _positron_detect_license_text(text::AbstractString)::String
+    occursin(r"\bMIT\b"i, text) && return "MIT"
+    if occursin(r"Apache License"i, text)
+        return occursin(r"Version 2\.0"i, text) ? "Apache-2.0" : "Apache"
+    end
+    if occursin(r"GNU (Lesser|Library) General Public License"i, text)
+        occursin(r"Version 3"i, text) && return "LGPL-3.0"
+        occursin(r"Version 2\.1"i, text) && return "LGPL-2.1"
+        return "LGPL"
+    end
+    if occursin(r"GNU Affero General Public License"i, text)
+        return "AGPL-3.0"
+    end
+    if occursin(r"GNU General Public License"i, text)
+        occursin(r"Version 3"i, text) && return "GPL-3.0"
+        occursin(r"Version 2"i, text) && return "GPL-2.0"
+        return "GPL"
+    end
+    occursin(r"BSD 3-Clause"i, text) && return "BSD-3-Clause"
+    occursin(r"BSD 2-Clause"i, text) && return "BSD-2-Clause"
+    if occursin(r"Mozilla Public License"i, text)
+        return occursin(r"2\.0", text) ? "MPL-2.0" : "MPL"
+    end
+    occursin(r"ISC License"i, text) && return "ISC"
+    occursin(r"Boost Software License"i, text) && return "BSL-1.0"
+    occursin(r"The Unlicense"i, text) && return "Unlicense"
+    occursin(r"European Union Public Licen"i, text) && return "EUPL"
+    # BSD text without a clause label: identify by its distinctive clause.
+    if occursin(r"Redistribution and use in source and binary forms"i, text)
+        return "BSD"
+    end
+    return ""
+end
+
+"""
+Detect a package's license from a license file in its source directory.
+Julia packages rarely declare `license` in Project.toml, but almost always
+ship a LICENSE/LICENSE.md file whose first lines name the license. Cached
+per path; returns "" when no license file is found or recognized.
+"""
+function _positron_read_license_file(package_path)::String
+    package_path isa AbstractString || return ""
+    isempty(package_path) && return ""
+    return get!(_POSITRON_LICENSE_BY_PATH, String(package_path)) do
+        for filename in (
+            "LICENSE", "LICENSE.md", "LICENSE.txt", "LICENSE.rst",
+            "License.md", "license", "COPYING", "COPYING.md",
+        )
+            license_path = joinpath(package_path, filename)
+            isfile(license_path) || continue
+            text = try
+                join(Iterators.take(eachline(license_path), 60), "\n")
+            catch
+                continue
+            end
+            label = _positron_detect_license_text(text)
+            isempty(label) || return label
+        end
+        return ""
+    end
+end
+
+"""
 Read and format the `authors` field from Project.toml/JuliaProject.toml for
 display: skips "contributors: ..." entries, strips trailing `<email>`
 addresses, and joins the remaining names with ", ". Returns "" when the
@@ -678,6 +853,10 @@ end
 Print detail fields for a single installed package as one JSON object, or
 `null` when the package is not installed. Called when the package detail
 editor opens; the result is merged over the package's list entry.
+
+The `stdlib` key is internal to the extension (used to suppress the
+juliapackages.com description overlay, which has stale entries for
+pre-stdlib packages like Dates.jl) and is not forwarded to Positron.
 """
 function _positron_package_detail(name::String)
     package_info = _positron_find_installed_package(name)
@@ -689,21 +868,47 @@ function _positron_package_detail(name::String)
     version_val = package_info.version
     version = version_val === nothing ? "" : string(version_val)
     package_path = _positron_package_source_path(package_info)
-    description, license, url = _positron_read_project_metadata(package_path)
-    isempty(description) && (description = _positron_read_package_description(package_path))
-    isempty(url) && (url = _positron_package_source_url(package_info))
-    isempty(url) && (url = _positron_registry_package_url(package_info.name))
+    stdlib = _positron_is_stdlib_path(package_path)
+
+    # Project.toml's `description` is a one-liner by convention: use it as the
+    # detail header's title, and the longer README paragraph as description.
+    title, license, url = _positron_read_project_metadata(package_path)
+    description = _positron_read_package_description(package_path)
     author = _positron_read_project_author(package_path)
-    source_repository = _positron_registry_name_for_package(package_info.name)
+    dependency_count = _positron_dependency_count(package_info)
+
+    if stdlib
+        # Standard libraries ship minimal Project.toml metadata: no authors,
+        # license, URL, or registry entry. They are part of Julia itself
+        # (MIT-licensed) and documented in the Julia manual; their only prose
+        # description is the first paragraph of docs/src/index.md.
+        if isempty(description)
+            description = _positron_first_markdown_paragraph(
+                joinpath(package_path, "docs", "src", "index.md"),
+            )
+        end
+        isempty(title) && (title = _positron_first_sentence(description))
+        isempty(license) && (license = "MIT")
+        isempty(url) && (url = _positron_stdlib_docs_url(package_info.name))
+        source_repository = "Julia standard library"
+    else
+        isempty(license) && (license = _positron_read_license_file(package_path))
+        isempty(url) && (url = _positron_package_source_url(package_info))
+        isempty(url) && (url = _positron_registry_package_url(package_info.name))
+        source_repository = _positron_registry_name_for_package(package_info.name)
+    end
 
     print("{")
     print("\"name\":", _positron_json_string(package_info.name))
     isempty(version) || print(",\"version\":", _positron_json_string(version))
+    isempty(title) || print(",\"title\":", _positron_json_string(title))
     isempty(author) || print(",\"author\":", _positron_json_string(author))
     isempty(license) || print(",\"license\":", _positron_json_string(license))
     isempty(source_repository) || print(",\"sourceRepository\":", _positron_json_string(source_repository))
     isempty(description) || print(",\"description\":", _positron_json_string(description))
     isempty(url) || print(",\"url\":", _positron_json_string(url))
+    print(",\"dependencyCount\":", dependency_count)
+    stdlib && print(",\"stdlib\":true")
     print("}")
 end
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -56,6 +56,22 @@ async function runActiveFile(editor: vscode.TextEditor): Promise<void> {
   }
 
   await document.save();
+
+  // Offer to install missing packages before running the file. The
+  // preflight runs in the Positron frontend and returns whether to
+  // proceed (false only if the user cancels).
+  try {
+    const proceed = await vscode.commands.executeCommand<boolean>(
+      "positron.missingPackages.preflight",
+      document.uri,
+    );
+    if (proceed === false) {
+      return;
+    }
+  } catch {
+    // Command not available in this Positron build; proceed normally.
+  }
+
   const escapedPath = escapeForJuliaString(document.uri.fsPath);
   await executeJuliaCode(`include("${escapedPath}")`);
 }

--- a/src/missingPackages.ts
+++ b/src/missingPackages.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import * as positron from "positron";
+
+/** Modules that are always available and never installable packages. */
+const BUILTIN_MODULES = new Set(["Base", "Core", "Main"]);
+
+/**
+ * Matches a `using`/`import` keyword at the start of a statement, capturing
+ * the clause list that follows.
+ */
+const IMPORT_STATEMENT_REGEX = /^\s*(?:using|import)\s+(.+)$/;
+
+/** Matches a valid Julia module identifier. */
+const IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_!]*$/;
+
+/**
+ * Extracts the set of top-level package names referenced by `using` and
+ * `import` statements in the given Julia source.
+ *
+ * Line-based, like the R analyzer: handles comma-separated clause lists
+ * (`using A, B`), selection lists (`using A: x, y` -> A), submodule paths
+ * (`import A.B` -> A), renames (`import A as B` -> A), and multiple
+ * statements per line (`using A; using B`). Relative imports (`import .Foo`)
+ * and Base/Core/Main are skipped. Macro-generated imports (`@eval using X`),
+ * multi-line clause lists, and `#= =#` block comments are not handled; a
+ * missed reference just means no prompt, and a false positive is dropped by
+ * the installed/installable filter downstream.
+ */
+export function parseJuliaPackageReferences(code: string): string[] {
+  const packages = new Set<string>();
+
+  for (const rawLine of code.split(/\r\n|\r|\n/)) {
+    // Strip line comments (best-effort: does not track '#' inside strings).
+    const line = rawLine.replace(/#.*$/, "");
+
+    for (const statement of line.split(";")) {
+      const match = IMPORT_STATEMENT_REGEX.exec(statement);
+      if (!match) {
+        continue;
+      }
+
+      // A selection list (`using A: x, y`) allows only a single module
+      // before the ':'; everything after it is selected names, not
+      // modules, so truncate there before splitting the comma list.
+      const clauseList = match[1].split(":")[0];
+
+      for (const rawClause of clauseList.split(",")) {
+        const clause = rawClause.trim();
+        if (clause.length === 0 || clause.startsWith(".")) {
+          continue;
+        }
+
+        // Drop a rename (` as B`), then take the module path's top-level
+        // segment (`A.B.C` -> `A`).
+        const modulePath = clause.split(/\s+as\s+/)[0].trim();
+        const topLevel = modulePath.split(".")[0].trim();
+
+        if (!IDENTIFIER_REGEX.test(topLevel)) {
+          continue;
+        }
+        if (BUILTIN_MODULES.has(topLevel)) {
+          continue;
+        }
+
+        packages.add(topLevel);
+      }
+    }
+  }
+
+  return [...packages];
+}
+
+/**
+ * The subset of JuliaPackageManager that the missing-packages analyzer
+ * needs: a single kernel round-trip that filters candidate names down to
+ * the ones that are not loadable but exist in a reachable registry.
+ */
+export interface MissingPackagesQuerier {
+  missingPackages(
+    names: string[],
+    token?: vscode.CancellationToken,
+  ): Promise<string[]>;
+}
+
+/**
+ * Analyzes Julia code and returns the packages it references that are not
+ * installed AND that are available in a reachable registry.
+ *
+ * The filtering happens in one Julia call: `Base.identify_package` drops
+ * anything loadable (stdlibs and active-project dependencies), and an exact
+ * registry name match keeps only what `Pkg.add` could actually install.
+ * This is what excludes the unpublished/GitHub-only case: a package that is
+ * not in a reachable registry is never offered.
+ */
+export async function listMissingJuliaPackages(
+  packageManager: MissingPackagesQuerier,
+  target: positron.RuntimeMissingPackagesTarget,
+  token?: vscode.CancellationToken,
+): Promise<positron.RuntimeMissingPackage[]> {
+  const code = await resolveCode(target);
+  if (!code) {
+    return [];
+  }
+
+  const references = parseJuliaPackageReferences(code);
+  if (references.length === 0) {
+    return [];
+  }
+
+  const missing = await packageManager.missingPackages(references, token);
+  return missing.map((name) => ({ name }));
+}
+
+/** Reads the code to analyze from the target's inline code or file URI. */
+async function resolveCode(
+  target: positron.RuntimeMissingPackagesTarget,
+): Promise<string | undefined> {
+  if (target.code !== undefined) {
+    return target.code;
+  }
+  if (target.uri) {
+    try {
+      const document = await vscode.workspace.openTextDocument(
+        vscode.Uri.parse(target.uri),
+      );
+      return document.getText();
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -295,6 +295,36 @@ export class JuliaPackageManager
     return this._parseStringArray(raw);
   }
 
+  /**
+   * Filter candidate package names down to the ones that are not loadable
+   * in the session (not a stdlib, not an active-project dependency) but
+   * exist by exact name in a reachable registry. Powers the session's
+   * listMissingPackages hook with a single kernel round-trip.
+   */
+  async missingPackages(
+    names: string[],
+    token?: vscode.CancellationToken,
+  ): Promise<string[]> {
+    const cleaned = this._uniquePackageNames(
+      names.map((name) => name.trim()).filter((name) => name.length > 0),
+    );
+
+    if (cleaned.length === 0) {
+      return [];
+    }
+
+    await this.sourcePackagesScript();
+
+    const raw = await this._executeAndCapture(
+      `_positron_missing_packages(${this._toJuliaStringVector(cleaned)})`,
+      positron.RuntimeCodeExecutionMode.Silent,
+      QUERY_TIMEOUT_MS,
+      token,
+    );
+
+    return this._parseStringArray(raw);
+  }
+
   async getPackageMetadata(
     packageNames: string[],
     token?: vscode.CancellationToken,

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -337,6 +337,59 @@ export class JuliaPackageManager
     return metadataMap;
   }
 
+  async getPackageDetail(
+    name: string,
+    token?: vscode.CancellationToken,
+  ): Promise<Partial<positron.LanguageRuntimePackage> | undefined> {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+
+    await this.sourcePackagesScript();
+
+    const escaped = this._escapeJuliaStringLiteral(trimmed);
+    const raw = await this._executeAndCapture(
+      `_positron_package_detail("${escaped}")`,
+      positron.RuntimeCodeExecutionMode.Silent,
+      QUERY_TIMEOUT_MS,
+      token,
+    );
+
+    const parsed = this._parseJsonValue(raw);
+    // `null` means the package is not installed.
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    const detail: Partial<positron.LanguageRuntimePackage> = {};
+    const copyString = (key: keyof positron.LanguageRuntimePackage) => {
+      const value = record[key];
+      if (typeof value === "string" && value.length > 0) {
+        (detail as Record<string, string>)[key] = value;
+      }
+    };
+    copyString("name");
+    copyString("version");
+    copyString("author");
+    copyString("license");
+    copyString("sourceRepository");
+    copyString("description");
+    copyString("url");
+
+    // Prefer the curated juliapackages.com description, matching the
+    // getPackages()/getPackageMetadata() behavior so the detail editor
+    // shows the same summary as the list entry.
+    const juliaPackagesDescription =
+      await this._getJuliaPackagesDescriptionCached(trimmed);
+    if (juliaPackagesDescription) {
+      detail.description = juliaPackagesDescription;
+    }
+
+    return detail;
+  }
+
   private _getJuliaPackagesDescriptionCached(
     packageName: string,
   ): Promise<string | undefined> {

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -1255,6 +1255,13 @@ function isUsefulPackageDescription(value: string): boolean {
     return false;
   }
 
+  // A single word is never a real description; it is a page label like
+  // "Author", "Popularity", or "Dependencies" that slipped past the
+  // heading-based extraction.
+  if (!/\s/.test(text)) {
+    return false;
+  }
+
   if (
     lower === "search" ||
     lower === "learn more" ||

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -45,6 +45,11 @@ export class JuliaPackageManager
     Promise<string | undefined>
   >();
 
+  private readonly _publishedDateCache = new Map<
+    string,
+    Promise<string | undefined>
+  >();
+
   private readonly _onDidChangePackages = new vscode.EventEmitter<
     void | string[]
   >();
@@ -148,11 +153,14 @@ export class JuliaPackageManager
   ): Promise<positron.LanguageRuntimePackage[]> {
     await this.sourcePackagesScript();
 
-    const packages = await this._listPackagesFromRuntime(token);
+    const stdlibNames = new Set<string>();
+    const packages = await this._listPackagesFromRuntime(token, stdlibNames);
 
     // Important: the packages pane uses this method, not only getPackageMetadata().
-    // Therefore, fetch and replace descriptions here too.
-    await this._replaceDescriptionsFromJuliaPackages(packages);
+    // Therefore, fetch and replace descriptions here too. Standard library
+    // packages are skipped: juliapackages.com carries stale entries for
+    // pre-stdlib packages of the same name (e.g. a "[DEPRECATED]" Dates.jl).
+    await this._replaceDescriptionsFromJuliaPackages(packages, stdlibNames);
 
     return packages;
   }
@@ -402,22 +410,74 @@ export class JuliaPackageManager
     };
     copyString("name");
     copyString("version");
+    copyString("title");
     copyString("author");
     copyString("license");
     copyString("sourceRepository");
     copyString("description");
     copyString("url");
 
-    // Prefer the curated juliapackages.com description, matching the
-    // getPackages()/getPackageMetadata() behavior so the detail editor
-    // shows the same summary as the list entry.
-    const juliaPackagesDescription =
-      await this._getJuliaPackagesDescriptionCached(trimmed);
-    if (juliaPackagesDescription) {
-      detail.description = juliaPackagesDescription;
+    // Number of direct dependencies, excluding stdlibs. Not yet in the
+    // vendored Positron API, but forwarded so the detail editor's DEPS stat
+    // lights up on builds that render it.
+    if (typeof record.dependencyCount === "number") {
+      (detail as Record<string, number>).dependencyCount =
+        record.dependencyCount;
+    }
+
+    const isStdlib = record.stdlib === true;
+
+    if (!isStdlib) {
+      // Prefer the curated juliapackages.com description, matching the
+      // getPackages()/getPackageMetadata() behavior so the detail editor
+      // shows the same summary as the list entry. Skipped for stdlibs, whose
+      // juliapackages.com entries describe stale pre-stdlib packages.
+      const juliaPackagesDescription =
+        await this._getJuliaPackagesDescriptionCached(trimmed);
+      if (juliaPackagesDescription) {
+        detail.description = juliaPackagesDescription;
+        if (!detail.title) {
+          detail.title = juliaPackagesDescription;
+        }
+      }
+
+      // Julia registries carry no publication dates; best-effort fetch the
+      // release date of the installed version from the package's GitHub
+      // repository (TagBot-conventional "v<version>" tags), cached per
+      // name@version.
+      if (detail.url && detail.version) {
+        const publishedDate = await this._getPublishedDateCached(
+          detail.url,
+          detail.version,
+        );
+        if (publishedDate) {
+          detail.publishedDate = publishedDate;
+        }
+      }
     }
 
     return detail;
+  }
+
+  private _getPublishedDateCached(
+    url: string,
+    version: string,
+  ): Promise<string | undefined> {
+    const repo = parseGitHubRepo(url);
+    if (!repo) {
+      return Promise.resolve(undefined);
+    }
+
+    const key = `${repo.owner}/${repo.name}@${version}`;
+    let cached = this._publishedDateCache.get(key);
+    if (!cached) {
+      cached = fetchPublishedDateFromGitHub(repo.owner, repo.name, version).catch(
+        () => undefined,
+      );
+      this._publishedDateCache.set(key, cached);
+    }
+
+    return cached;
   }
 
   private _getJuliaPackagesDescriptionCached(
@@ -439,9 +499,13 @@ export class JuliaPackageManager
 
   private async _replaceDescriptionsFromJuliaPackages(
     packages: positron.LanguageRuntimePackage[],
+    skipNames?: Set<string>,
   ): Promise<void> {
     await Promise.allSettled(
       packages.map(async (pkg) => {
+        if (skipNames?.has(pkg.name)) {
+          return;
+        }
         const description = await this._getJuliaPackagesDescriptionCached(
           pkg.name,
         );
@@ -454,6 +518,7 @@ export class JuliaPackageManager
 
   private async _listPackagesFromRuntime(
     token?: vscode.CancellationToken,
+    stdlibNames?: Set<string>,
   ): Promise<positron.LanguageRuntimePackage[]> {
     const raw = await this._executeAndCapture(
       "_positron_list_packages()",
@@ -462,7 +527,7 @@ export class JuliaPackageManager
       token,
     );
 
-    return this._parsePackages(raw);
+    return this._parsePackages(raw, stdlibNames);
   }
 
   private _findChangedPackageNames(
@@ -486,7 +551,10 @@ export class JuliaPackageManager
     return Array.from(new Set(names));
   }
 
-  private _parsePackages(raw: string): positron.LanguageRuntimePackage[] {
+  private _parsePackages(
+    raw: string,
+    stdlibNames?: Set<string>,
+  ): positron.LanguageRuntimePackage[] {
     const parsed = this._parseJsonValue(raw);
     if (!Array.isArray(parsed)) {
       return [];
@@ -499,6 +567,12 @@ export class JuliaPackageManager
         const name = typeof record.name === "string" ? record.name : "";
         const version =
           typeof record.version === "string" ? record.version : "";
+
+        // Internal marker from the Julia helper; consumed here (to skip the
+        // juliapackages.com description overlay) and not forwarded.
+        if (record.stdlib === true && name.length > 0) {
+          stdlibNames?.add(name);
+        }
 
         return {
           id: typeof record.id === "string" ? record.id : `${name}-${version}`,
@@ -925,6 +999,100 @@ function fetchDescriptionFromJuliaPackages(
       html ? extractJuliaPackagesDescription(html, slug) : undefined,
     )
     .catch(() => undefined);
+}
+
+/** Parses "https://github.com/owner/repo(.git)" into its owner/repo parts. */
+function parseGitHubRepo(
+  url: string,
+): { owner: string; name: string } | undefined {
+  const match = url.match(
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:[/?#]|$)/i,
+  );
+  if (!match) {
+    return undefined;
+  }
+  return { owner: match[1], name: match[2] };
+}
+
+/**
+ * Fetch the publication date (YYYY-MM-DD) of a package version from its
+ * GitHub release. Julia's registries carry no publication dates, but nearly
+ * all registered packages are released via TagBot, which creates a GitHub
+ * release tagged "v<version>". Best-effort: resolves undefined on any
+ * failure (missing release, rate limit, network error).
+ */
+function fetchPublishedDateFromGitHub(
+  owner: string,
+  repo: string,
+  version: string,
+): Promise<string | undefined> {
+  const url =
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/` +
+    `${encodeURIComponent(repo)}/releases/tags/v${encodeURIComponent(version)}`;
+
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const done = (value: string | undefined) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    };
+
+    const request = https.get(
+      url,
+      {
+        headers: {
+          "User-Agent": "Positron-Julia",
+          Accept: "application/vnd.github+json",
+        },
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          done(undefined);
+          return;
+        }
+
+        res.setEncoding("utf8");
+
+        let data = "";
+        res.on("data", (chunk: string) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          try {
+            const release = JSON.parse(data) as { published_at?: unknown };
+            const publishedAt =
+              typeof release.published_at === "string"
+                ? release.published_at
+                : undefined;
+            done(
+              publishedAt && publishedAt.length >= 10
+                ? publishedAt.slice(0, 10)
+                : undefined,
+            );
+          } catch {
+            done(undefined);
+          }
+        });
+        res.on("error", () => {
+          done(undefined);
+        });
+      },
+    );
+
+    request.on("error", () => {
+      done(undefined);
+    });
+
+    request.setTimeout(5000, () => {
+      done(undefined);
+      request.destroy();
+    });
+  });
 }
 
 function normalizeJuliaPackageName(packageName: string): string {

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,7 @@ import {
   JupyterKernelSpec,
 } from "./positron-supervisor";
 import { JuliaPackageManager } from "./packages";
+import { listMissingJuliaPackages } from "./missingPackages";
 
 interface RuntimeResourceUsage {
   [key: string]: unknown;
@@ -479,6 +480,13 @@ export class JuliaSession
 
   getPackageManager(): positron.LanguageRuntimePackageManager {
     return this._packageManager;
+  }
+
+  async listMissingPackages(
+    target: positron.RuntimeMissingPackagesTarget,
+    token?: vscode.CancellationToken,
+  ): Promise<positron.RuntimeMissingPackage[]> {
+    return listMissingJuliaPackages(this._packageManager, target, token);
   }
 
   updateSessionName(name: string): void {

--- a/typings/positron.d.ts
+++ b/typings/positron.d.ts
@@ -1268,6 +1268,15 @@ declare module 'positron' {
 		description?: string;
 		/** Optional package website, repository, or documentation URL. */
 		url?: string;
+
+		/** One-line title/summary, richer than `description`. From the detail RPC. */
+		title?: string;
+
+		/** Display-ready author/maintainer string (already normalized by the runtime). */
+		author?: string;
+
+		/** Source repository label or URL (e.g. "CRAN", or a Project-URL). */
+		sourceRepository?: string;
 	}
 
 	/**
@@ -1302,6 +1311,18 @@ declare module 'positron' {
 			packageNames: string[],
 			token?: vscode.CancellationToken,
 		): Thenable<Map<string, Partial<LanguageRuntimePackage>>>;
+
+		/**
+		 * Fetch detailed metadata for a single package, called when the package
+		 * detail editor opens. Cheap, kernel-local fields only. Returns a partial
+		 * package to merge over the list entry, or undefined when unsupported.
+		 * @param name Package name
+		 * @param token Optional cancellation token
+		 */
+		getPackageDetail?(
+			name: string,
+			token?: vscode.CancellationToken,
+		): Thenable<Partial<LanguageRuntimePackage> | undefined>;
 
 		/**
 		 * Fired when the set of loaded/attached packages may have changed

--- a/typings/positron.d.ts
+++ b/typings/positron.d.ts
@@ -1235,6 +1235,47 @@ declare module 'positron' {
 		 * package management (e.g. to power the Packages pane).
 		 */
 		getPackageManager?(): LanguageRuntimePackageManager;
+
+		/**
+		 * Statically analyze code (or a file) and return packages that are
+		 * referenced but NOT installed AND that can be installed in this
+		 * session's environment.
+		 *
+		 * MUST NOT return packages that cannot be resolved/installed (e.g.
+		 * GitHub-only R packages, unknown PyPI names). SHOULD be fast and cache
+		 * internally; callers will not block UI on it.
+		 *
+		 * @param target The code or file to analyze.
+		 * @param token Optional cancellation token.
+		 */
+		listMissingPackages?(target: RuntimeMissingPackagesTarget, token?: vscode.CancellationToken): Thenable<RuntimeMissingPackage[]>;
+	}
+
+	/**
+	 * Describes a package that is referenced by code but not installed in a
+	 * session's environment, and that the session knows how to install.
+	 */
+	export interface RuntimeMissingPackage {
+		/** Name to pass to installPackages (the installable/repository name). */
+		readonly name: string;
+
+		/**
+		 * The symbol as referenced in code, when it differs from `name` (e.g.
+		 * python import `cv2` -> install `opencv-python`). Used for display only.
+		 */
+		readonly referencedName?: string;
+	}
+
+	/**
+	 * Describes the code to analyze for missing packages. Callers supply either
+	 * raw code or the URI of a saved file (not both).
+	 */
+	export interface RuntimeMissingPackagesTarget {
+		/** Raw code to analyze (notebook cells, quarto chunks, unsaved buffers). */
+		readonly code?: string;
+
+		/** URI of a saved file to analyze. The runtime may read/parse it directly. */
+		readonly uri?: string;
 	}
 
 	/**


### PR DESCRIPTION
Closes #33
Closes #34

Mirrors two recently merged Positron core features into the Julia extension, matching the R (ark) and Python implementations.

## Package detail editor (#33, upstream posit-dev/positron#14440 + posit-dev/ark#1291)

Positron's Packages pane now opens a detail editor when a package is clicked, fetching detail fields via a new optional `getPackageDetail` hook on the runtime package manager.

- `JuliaPackageManager.getPackageDetail(name)` calls a new `_positron_package_detail` helper in `scripts/packages/packages.jl`, which returns `name`, `version`, `author` (from `Project.toml` `authors`, with emails and `contributors:` entries stripped), `license`, `sourceRepository` (the containing registry's name, e.g. `"General"` — the Julia analog of ark's `"CRAN"`), `description`, and `url`, reusing the existing project-metadata readers. Returns `null` → `undefined` for uninstalled packages.
- Julia has no title or publication-date metadata, so `title`/`publishedDate` are omitted (the detail editor leaves those fields blank).
- The curated juliapackages.com description overlay is applied, matching `getPackages()`/`getPackageMetadata()`.

## Prompt to install missing packages (#34, upstream posit-dev/positron#14573)

Positron now offers to install packages referenced by scripts/notebooks that aren't installed, via a per-session `listMissingPackages` hook plus a `positron.missingPackages.preflight` command gate.

- New `src/missingPackages.ts`: `parseJuliaPackageReferences` extracts top-level packages from `using`/`import` statements (comma lists, selection lists `using A: x`, submodule paths `import A.B`, renames `import A as B`, multiple statements per line; skips relative imports and `Base`/`Core`/`Main`).
- New `_positron_missing_packages` Julia helper filters candidates in **one** kernel round-trip: `Base.identify_package` drops anything loadable (stdlibs and active-project deps — something a registry-only check would get wrong), and an exact registry-name match keeps only what `Pkg.add` can actually install, so unresolvable names are never offered.
- `JuliaSession.listMissingPackages` wires the hook; `julia.runFile`'s saved-file path is gated through the preflight command, proceeding normally on older Positron builds (command lookup failure is caught).

Both hooks are optional and discovered by core (same pattern as the existing `getPackageMetadata?`) — no activation or `package.json` changes needed, and older Positron builds are unaffected.

## Known limitations

- Two of the three upstream missing-package surfaces are gated in Positron **core** to R/Python and can't be enabled from this extension: the editor action-bar badge's `when` clause only covers `python`/`r`/quarto language IDs, and the console error suggestion only matches Python/R error message patterns (Julia's `Package Foo not found in current path` is not recognized). The preflight modal and the two "Packages: …" command-palette commands are language-agnostic and work with this PR. Worth an upstream issue to add Julia to both.
- The `using`/`import` parser is line-based like the R analyzer: `@eval using X`, multi-line clause lists, and `#= =#` block comments aren't handled. Missed references just mean no prompt; false positives are dropped by the installed/installable filter.
- `parseJuliaPackageReferences` has no automated tests since the repo has no TS test infrastructure (existing gap); the Julia-side filtering is covered by the test suite.

## Testing

- `npm run compile` and `npm run bundle` pass.
- `npm run test:julia`: 950/950 pass, including new testsets for `_positron_package_detail`, `_positron_read_project_author`, and `_positron_missing_packages` (installed / stdlib / unregistered / registered-but-not-installed cases).
- Parser behavior spot-verified against 15 representative `using`/`import` forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)