### PR TITLE
v0.2.0: shadowing-proof package helpers, Pkg REPL console input, Create New Package command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 - **Variables Pane** — Browse all session variables with type and value summaries.
 - **Help Integration** — View Julia documentation inline via Positron's Help pane.
 - **Plots** — Julia plots are captured and displayed in Positron's Plots pane.
-- **Package Pane** — Browse and manage Julia packages directly within Positron. One-line Pkg commands (`] add DataFrames`, `] status`) work in the console.
+- **Package Pane** — Browse and manage Julia packages directly within Positron.
+- **Pkg REPL Mode** — Type `]` in the console to switch to the `pkg>` prompt, run Pkg commands like `status` or `add DataFrames`, and type `back` (or `exit`) to return to `julia>`. One-shot commands (`] add DataFrames`) work too.
 - **Create New Package** — Scaffold a new package with [PkgTemplates.jl](https://github.com/JuliaCI/PkgTemplates.jl) via `Julia: Create New Package` in the command palette: tests and README always included, plus optional git repository, MIT license, GitHub Actions CI, and Documenter docs.
 - **TestItem Compatible** - Uses the same testing system as `julia-vscode`
 - **Debugger** - Use breakpoints, inspect local and global variables, etc.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 - **Help Integration** — View Julia documentation inline via Positron's Help pane.
 - **Plots** — Julia plots are captured and displayed in Positron's Plots pane.
 - **Package Pane** — Browse and manage Julia packages directly within Positron.
-- **Pkg REPL Mode** — Type `]` in the console to switch to the `pkg>` prompt, run Pkg commands like `status` or `add DataFrames`, and type `back` (or `exit`) to return to `julia>`. One-shot commands (`] add DataFrames`) work too.
+- **Pkg REPL Mode** — Type `]` at an empty console prompt to switch to `pkg>`, run Pkg commands like `status` or `add DataFrames`, and press Backspace at an empty `pkg>` prompt to return to `julia>`. One-shot commands (`] add DataFrames`) work too.
 - **Create New Package** — Scaffold a new package with [PkgTemplates.jl](https://github.com/JuliaCI/PkgTemplates.jl) via `Julia: Create New Package` in the command palette: tests and README always included, plus optional git repository, MIT license, GitHub Actions CI, and Documenter docs.
 - **TestItem Compatible** - Uses the same testing system as `julia-vscode`
 - **Debugger** - Use breakpoints, inspect local and global variables, etc.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 - **Variables Pane** — Browse all session variables with type and value summaries.
 - **Help Integration** — View Julia documentation inline via Positron's Help pane.
 - **Plots** — Julia plots are captured and displayed in Positron's Plots pane.
-- **Package Pane** — Browse and manage Julia packages directly within Positron.
+- **Package Pane** — Browse and manage Julia packages directly within Positron. One-line Pkg commands (`] add DataFrames`, `] status`) work in the console.
+- **Create New Package** — Scaffold a new package with [PkgTemplates.jl](https://github.com/JuliaCI/PkgTemplates.jl) via `Julia: Create New Package` in the command palette: tests and README always included, plus optional git repository, MIT license, GitHub Actions CI, and Documenter docs.
 - **TestItem Compatible** - Uses the same testing system as `julia-vscode`
 - **Debugger** - Use breakpoints, inspect local and global variables, etc.
 - **Formatting** — Format Document (Shift+Alt+F) and Format Selection (Ctrl+K Ctrl+F) via [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl), powered by the language server. Configurable through a `.JuliaFormatter.toml` file at the workspace root.

--- a/julia/Positron/src/kernel.jl
+++ b/julia/Positron/src/kernel.jl
@@ -810,12 +810,12 @@ end
 # Pkg REPL mode
 # -------------------------------------------------------------------------
 # Forked from julia-vscode's REPL integration, where a LineEdit keymap bound
-# to `]` transitions the terminal REPL into Pkg.REPLMode. A Jupyter-based
-# console never sees raw keystrokes, so the transition happens on submission
-# instead: a bare `]` enters the mode, Positron's `prompt_state` UI event
-# switches the console prompt to the environment-aware `pkg>`, and every
-# subsequent submission runs as a Pkg REPL command until the user leaves the
-# mode (issue #35).
+# to `]` transitions the terminal REPL into Pkg.REPLMode. Positron's console is
+# Jupyter-backed, so the extension binds the empty-prompt `]` key on the
+# frontend and this kernel handler also supports submitted bare `]` input.
+# Positron's `prompt_state` UI event switches the console prompt to the
+# environment-aware `pkg>`, and every subsequent submission runs as a Pkg REPL
+# command until the user leaves the mode (issue #35).
 
 # Default console prompts. Keep in sync with the session dynState in the
 # extension's src/session.ts.
@@ -827,9 +827,8 @@ Whether the console is currently in Pkg REPL mode.
 """
 const PKG_REPL_MODE = Ref(false)
 
-# The terminal REPL leaves Pkg mode via the Backspace/Ctrl-C keystrokes,
-# which never reach a Jupyter kernel; these commands are the console
-# equivalent (none of them is a valid Pkg REPL command).
+# The extension binds Backspace at an empty `pkg>` console input to exit the
+# mode. These typed commands remain useful when input is submitted normally.
 const PKG_REPL_EXIT_COMMANDS = ("back", "exit", "quit")
 
 """
@@ -882,13 +881,15 @@ function update_console_prompts!()
     end
 end
 
-function enter_pkg_repl_mode!()
+function enter_pkg_repl_mode!(; show_message::Bool = true)
     PKG_REPL_MODE[] = true
     update_console_prompts!()
-    println(
-        "Entered Pkg REPL mode. Run commands like `status` or `add DataFrames`; " *
-        "type `back` or `exit` to return to the julia> prompt.",
-    )
+    if show_message
+        println(
+            "Entered Pkg REPL mode. Run commands like `status` or `add DataFrames`; " *
+            "press Backspace at an empty pkg> prompt or type `back` to return to julia>.",
+        )
+    end
 end
 
 function exit_pkg_repl_mode!()

--- a/julia/Positron/src/kernel.jl
+++ b/julia/Positron/src/kernel.jl
@@ -735,6 +735,11 @@ This implementation uses Meta.parseall which correctly handles multiple expressi
 and checks if any of them are incomplete.
 """
 function check_code_complete(code::String)
+    # In Pkg REPL mode every submission is a single Pkg command line.
+    if PKG_REPL_MODE[]
+        return "complete"
+    end
+
     # REPL special-mode one-liners (`] add X`, `?foo`, `;ls`) never parse as
     # valid Julia syntax, so without this check the console would report them
     # as invalid input. They execute through IJulia's special modes (and our
@@ -801,21 +806,31 @@ function install_is_complete_handler!()
     kernel_log_info("Installed custom is_complete_request handler")
 end
 
-"""
-Message printed when the user tries to enter the interactive Pkg REPL with a
-bare `]`. A Jupyter-based console has no modal prompt, so instead of silently
-doing nothing (issue #35), explain the supported one-line form.
-"""
-const PKG_REPL_GUIDANCE = """
-The interactive Pkg REPL (pkg>) is not available in Positron's console.
-Run Pkg commands on a single line instead:
+# -------------------------------------------------------------------------
+# Pkg REPL mode
+# -------------------------------------------------------------------------
+# Forked from julia-vscode's REPL integration, where a LineEdit keymap bound
+# to `]` transitions the terminal REPL into Pkg.REPLMode. A Jupyter-based
+# console never sees raw keystrokes, so the transition happens on submission
+# instead: a bare `]` enters the mode, Positron's `prompt_state` UI event
+# switches the console prompt to the environment-aware `pkg>`, and every
+# subsequent submission runs as a Pkg REPL command until the user leaves the
+# mode (issue #35).
 
-  ] status              # show installed packages
-  ] add DataFrames      # install a package
-  ] help                # list all Pkg commands
+# Default console prompts. Keep in sync with the session dynState in the
+# extension's src/session.ts.
+const JULIA_INPUT_PROMPT = "julia>"
+const JULIA_CONTINUATION_PROMPT = "      "
 
-Or call the Pkg API directly, e.g. import Pkg; Pkg.add("DataFrames").
 """
+Whether the console is currently in Pkg REPL mode.
+"""
+const PKG_REPL_MODE = Ref(false)
+
+# The terminal REPL leaves Pkg mode via the Backspace/Ctrl-C keystrokes,
+# which never reach a Jupyter kernel; these commands are the console
+# equivalent (none of them is a valid Pkg REPL command).
+const PKG_REPL_EXIT_COMMANDS = ("back", "exit", "quit")
 
 """
 Extract the Pkg REPL command from Pkg-mode console input (a single line
@@ -827,6 +842,98 @@ function extract_pkg_repl_command(code::AbstractString)::Union{String,Nothing}
     startswith(stripped, ']') || return nothing
     occursin('\n', stripped) && return nothing
     return String(strip(chop(stripped; head = 1, tail = 0)))
+end
+
+"""
+Environment-aware Pkg prompt, mirroring the terminal REPL's `(@v1.12) pkg>`
+and `(MyProject) pkg>`. Derived directly from the active project because
+`Pkg.REPLMode.promptf` lives in Pkg's REPL extension, which is not loaded in
+a Jupyter kernel.
+"""
+function pkg_repl_prompt()::String
+    label = try
+        project_file = Base.active_project()
+        if project_file === nothing
+            ""
+        else
+            in_shared_env = any(Base.DEPOT_PATH) do depot
+                startswith(project_file, joinpath(depot, "environments"))
+            end
+            name = basename(dirname(project_file))
+            in_shared_env ? "@" * name : name
+        end
+    catch
+        ""
+    end
+    return isempty(label) ? "pkg>" : "($label) pkg>"
+end
+
+"""
+Push the console prompts matching the current mode to the frontend.
+"""
+function update_console_prompts!()
+    kernel = get_kernel()
+    kernel.started || return
+    if PKG_REPL_MODE[]
+        prompt = pkg_repl_prompt()
+        set_console_prompts!(kernel.ui, prompt, " "^textwidth(prompt))
+    else
+        set_console_prompts!(kernel.ui, JULIA_INPUT_PROMPT, JULIA_CONTINUATION_PROMPT)
+    end
+end
+
+function enter_pkg_repl_mode!()
+    PKG_REPL_MODE[] = true
+    update_console_prompts!()
+    println(
+        "Entered Pkg REPL mode. Run commands like `status` or `add DataFrames`; " *
+        "type `back` or `exit` to return to the julia> prompt.",
+    )
+end
+
+function exit_pkg_repl_mode!()
+    PKG_REPL_MODE[] = false
+    update_console_prompts!()
+end
+
+"""
+Run a Pkg REPL command string (e.g. "add DataFrames") the way the terminal
+Pkg REPL would, writing output to the kernel's captured stdout. Reuses
+IJulia's version-aware bridge, which also lazy-loads Pkg.
+"""
+function run_pkg_repl_command(command::AbstractString)
+    IJulia.do_pkg_cmd(String(command))
+    return nothing
+end
+
+"""
+Whether the submitted code is one of the extension's own non-silent
+executions (package-pane mutations like install/update run as Interactive so
+their Pkg output shows in the console). These must run as normal Julia even
+while the console sits in Pkg REPL mode.
+"""
+function is_extension_internal_code(code::AbstractString)::Bool
+    return startswith(strip(code), "_PositronPackages.")
+end
+
+"""
+Handle console input while Pkg REPL mode is active: exit commands leave the
+mode, a leading `]` is tolerated (and stripped), an empty line stays in the
+mode like the terminal REPL, and anything else runs as a Pkg REPL command.
+"""
+function execute_pkg_mode_request(ijulia_kernel, msg)
+    input = strip(msg.content["code"]::String)
+    command = startswith(input, ']') ? strip(chop(input; head = 1, tail = 0)) : input
+
+    if lowercase(String(command)) in PKG_REPL_EXIT_COMMANDS
+        return execute_positron_action(ijulia_kernel, msg) do
+            exit_pkg_repl_mode!()
+        end
+    end
+
+    return execute_positron_action(ijulia_kernel, msg) do
+        isempty(command) || run_pkg_repl_command(String(command))
+    end
 end
 
 """
@@ -848,19 +955,30 @@ function install_execute_request_handler!()
 
     IJulia.handlers["execute_request"] = function (socket, ijulia_kernel, msg)
         code = msg.content["code"]::String
+        silent = msg.content["silent"]::Bool
+
+        # Background executions from the extension (silent package-pane
+        # queries, Interactive install/update mutations) are never console
+        # REPL-mode input.
+        if silent || is_extension_internal_code(code)
+            return original_execute_request(socket, ijulia_kernel, msg)
+        end
+
+        if PKG_REPL_MODE[]
+            return execute_pkg_mode_request(ijulia_kernel, msg)
+        end
 
         pkg_command = extract_pkg_repl_command(code)
         if pkg_command !== nothing
             if isempty(pkg_command)
-                # Bare `]`: IJulia would run an empty Pkg command and produce
-                # no output at all. Print guidance instead so the input
-                # visibly does something.
+                # Bare `]`: switch the console into Pkg REPL mode, like the
+                # terminal REPL's `]` keybinding.
                 return execute_positron_action(ijulia_kernel, msg) do
-                    print(PKG_REPL_GUIDANCE)
+                    enter_pkg_repl_mode!()
                 end
             end
 
-            # One-line commands (`] add Foo`) are handled by IJulia's own
+            # One-shot commands (`] add Foo`) are handled by IJulia's own
             # execute path; normalize surrounding whitespace so its `^\\]`
             # match always fires.
             msg.content["code"] = String(strip(code))

--- a/julia/Positron/src/kernel.jl
+++ b/julia/Positron/src/kernel.jl
@@ -735,6 +735,14 @@ This implementation uses Meta.parseall which correctly handles multiple expressi
 and checks if any of them are incomplete.
 """
 function check_code_complete(code::String)
+    # REPL special-mode one-liners (`] add X`, `?foo`, `;ls`) never parse as
+    # valid Julia syntax, so without this check the console would report them
+    # as invalid input. They execute through IJulia's special modes (and our
+    # own Pkg/help routing), so report them complete.
+    if is_repl_magic_line(code)
+        return "complete"
+    end
+
     try
         ex = Meta.parseall(code)
 
@@ -753,6 +761,17 @@ function check_code_complete(code::String)
         kernel_log_warn("Error parsing code for completeness check: $e")
         return "invalid"
     end
+end
+
+"""
+Whether the input is a single-line REPL special-mode command: Pkg mode
+(`] add X`), help mode (`?foo`), or shell mode (`;ls`).
+"""
+function is_repl_magic_line(code::AbstractString)::Bool
+    stripped = strip(code)
+    isempty(stripped) && return false
+    occursin('\n', stripped) && return false
+    return first(stripped) in (']', '?', ';')
 end
 
 """
@@ -783,8 +802,37 @@ function install_is_complete_handler!()
 end
 
 """
+Message printed when the user tries to enter the interactive Pkg REPL with a
+bare `]`. A Jupyter-based console has no modal prompt, so instead of silently
+doing nothing (issue #35), explain the supported one-line form.
+"""
+const PKG_REPL_GUIDANCE = """
+The interactive Pkg REPL (pkg>) is not available in Positron's console.
+Run Pkg commands on a single line instead:
+
+  ] status              # show installed packages
+  ] add DataFrames      # install a package
+  ] help                # list all Pkg commands
+
+Or call the Pkg API directly, e.g. import Pkg; Pkg.add("DataFrames").
+"""
+
+"""
+Extract the Pkg REPL command from Pkg-mode console input (a single line
+starting with `]`, as in `] add DataFrames`). Returns `nothing` when the code
+is not Pkg-mode input; a bare `]` returns an empty string.
+"""
+function extract_pkg_repl_command(code::AbstractString)::Union{String,Nothing}
+    stripped = strip(String(code))
+    startswith(stripped, ']') || return nothing
+    occursin('\n', stripped) && return nothing
+    return String(strip(chop(stripped; head = 1, tail = 0)))
+end
+
+"""
 Install a custom execute_request handler that routes REPL help-mode (`?topic`)
-to Positron's Help pane instead of returning HTML to the Viewer pane.
+to Positron's Help pane instead of returning HTML to the Viewer pane, and
+gives Pkg-mode input (`]`) a sensible behavior in the console.
 """
 function install_execute_request_handler!()
     if !isdefined(IJulia, :handlers)
@@ -800,8 +848,26 @@ function install_execute_request_handler!()
 
     IJulia.handlers["execute_request"] = function (socket, ijulia_kernel, msg)
         code = msg.content["code"]::String
-        topic = extract_help_topic_from_code(code)
 
+        pkg_command = extract_pkg_repl_command(code)
+        if pkg_command !== nothing
+            if isempty(pkg_command)
+                # Bare `]`: IJulia would run an empty Pkg command and produce
+                # no output at all. Print guidance instead so the input
+                # visibly does something.
+                return execute_positron_action(ijulia_kernel, msg) do
+                    print(PKG_REPL_GUIDANCE)
+                end
+            end
+
+            # One-line commands (`] add Foo`) are handled by IJulia's own
+            # execute path; normalize surrounding whitespace so its `^\\]`
+            # match always fires.
+            msg.content["code"] = String(strip(code))
+            return original_execute_request(socket, ijulia_kernel, msg)
+        end
+
+        topic = extract_help_topic_from_code(code)
         if topic === nothing
             return original_execute_request(socket, ijulia_kernel, msg)
         end
@@ -812,102 +878,116 @@ function install_execute_request_handler!()
             return original_execute_request(socket, ijulia_kernel, msg)
         end
 
-        ijulia_kernel.execute_msg = msg
-        ijulia_kernel.stdio_bytes = 0
-        silent = msg.content["silent"]::Bool
-        store_history = get(msg.content, "store_history", !silent)::Bool
-        empty!(ijulia_kernel.execute_payloads)
-
-        if !silent
-            ijulia_kernel.n += 1
-            IJulia.send_ipython(
-                ijulia_kernel.publish[],
-                ijulia_kernel,
-                IJulia.msg_pub(
-                    msg,
-                    "execute_input",
-                    Dict("execution_count" => ijulia_kernel.n, "code" => code),
-                ),
-            )
-        end
-
-        if store_history
-            ijulia_kernel.In[ijulia_kernel.n] = code
-        end
-
-        try
-            foreach(Base.invokelatest, IJulia._preexecute_hooks)
-
-            if !silent
-                show_help!(positron_kernel.help, topic)
-            end
-
-            user_expressions = Dict{String,Any}()
-            for (v::String, ex::String) in get(msg.content, "user_expressions", Dict{String,Any}())
-                try
-                    value = include_string(ijulia_kernel.current_module, ex)
-                    user_expressions[v] = Dict(
-                        "status" => "ok",
-                        "data" => Base.invokelatest(IJulia.display_dict, value),
-                        "metadata" => Base.invokelatest(IJulia.metadata, value),
-                    )
-                catch e
-                    user_expressions[v] = Dict(
-                        "status" => "error",
-                        IJulia.error_content(e, catch_backtrace())...,
-                    )
-                end
-            end
-
-            foreach(Base.invokelatest, IJulia._postexecute_hooks)
-
-            IJulia.flush_all()
-            yield()
-            if haskey(ijulia_kernel.bufs, "stdout")
-                IJulia.send_stdout(ijulia_kernel)
-            end
-            if haskey(ijulia_kernel.bufs, "stderr")
-                IJulia.send_stderr(ijulia_kernel)
-            end
-
-            Base.invokelatest(IJulia.flush_kernel_display, ijulia_kernel)
-
-            IJulia.send_ipython(
-                ijulia_kernel.requests[],
-                ijulia_kernel,
-                IJulia.msg_reply(
-                    msg,
-                    "execute_reply",
-                    Dict(
-                        "status" => "ok",
-                        "payload" => ijulia_kernel.execute_payloads,
-                        "execution_count" => ijulia_kernel.n,
-                        "user_expressions" => user_expressions,
-                    ),
-                ),
-            )
-            empty!(ijulia_kernel.execute_payloads)
-        catch e
-            bt = catch_backtrace()
-            try
-                IJulia.flush_all()
-                foreach(Base.invokelatest, IJulia._posterror_hooks)
-            catch
-            end
-            empty!(ijulia_kernel.displayqueue)
-            content = IJulia.error_content(e, bt)
-            IJulia.send_ipython(ijulia_kernel.publish[], ijulia_kernel, IJulia.msg_pub(msg, "error", content))
-            content["status"] = "error"
-            content["execution_count"] = ijulia_kernel.n
-            IJulia.send_ipython(
-                ijulia_kernel.requests[],
-                ijulia_kernel,
-                IJulia.msg_reply(msg, "execute_reply", content),
-            )
+        return execute_positron_action(ijulia_kernel, msg) do
+            show_help!(positron_kernel.help, topic)
         end
     end
 
     kernel_log_info("Installed custom execute_request handler")
+end
+
+"""
+Run the standard execute_request bookkeeping (execute_input broadcast,
+history, execution hooks, stdout/stderr flushing, execute_reply) around
+`action`, instead of evaluating the submitted code. Used for console inputs
+that Positron handles itself: help-mode routing and Pkg-mode guidance.
+"""
+function execute_positron_action(action::Function, ijulia_kernel, msg)
+    code = msg.content["code"]::String
+
+    ijulia_kernel.execute_msg = msg
+    ijulia_kernel.stdio_bytes = 0
+    silent = msg.content["silent"]::Bool
+    store_history = get(msg.content, "store_history", !silent)::Bool
+    empty!(ijulia_kernel.execute_payloads)
+
+    if !silent
+        ijulia_kernel.n += 1
+        IJulia.send_ipython(
+            ijulia_kernel.publish[],
+            ijulia_kernel,
+            IJulia.msg_pub(
+                msg,
+                "execute_input",
+                Dict("execution_count" => ijulia_kernel.n, "code" => code),
+            ),
+        )
+    end
+
+    if store_history
+        ijulia_kernel.In[ijulia_kernel.n] = code
+    end
+
+    try
+        foreach(Base.invokelatest, IJulia._preexecute_hooks)
+
+        if !silent
+            action()
+        end
+
+        user_expressions = Dict{String,Any}()
+        for (v::String, ex::String) in get(msg.content, "user_expressions", Dict{String,Any}())
+            try
+                value = include_string(ijulia_kernel.current_module, ex)
+                user_expressions[v] = Dict(
+                    "status" => "ok",
+                    "data" => Base.invokelatest(IJulia.display_dict, value),
+                    "metadata" => Base.invokelatest(IJulia.metadata, value),
+                )
+            catch e
+                user_expressions[v] = Dict(
+                    "status" => "error",
+                    IJulia.error_content(e, catch_backtrace())...,
+                )
+            end
+        end
+
+        foreach(Base.invokelatest, IJulia._postexecute_hooks)
+
+        IJulia.flush_all()
+        yield()
+        if haskey(ijulia_kernel.bufs, "stdout")
+            IJulia.send_stdout(ijulia_kernel)
+        end
+        if haskey(ijulia_kernel.bufs, "stderr")
+            IJulia.send_stderr(ijulia_kernel)
+        end
+
+        Base.invokelatest(IJulia.flush_kernel_display, ijulia_kernel)
+
+        IJulia.send_ipython(
+            ijulia_kernel.requests[],
+            ijulia_kernel,
+            IJulia.msg_reply(
+                msg,
+                "execute_reply",
+                Dict(
+                    "status" => "ok",
+                    "payload" => ijulia_kernel.execute_payloads,
+                    "execution_count" => ijulia_kernel.n,
+                    "user_expressions" => user_expressions,
+                ),
+            ),
+        )
+        empty!(ijulia_kernel.execute_payloads)
+    catch e
+        bt = catch_backtrace()
+        try
+            IJulia.flush_all()
+            foreach(Base.invokelatest, IJulia._posterror_hooks)
+        catch
+        end
+        empty!(ijulia_kernel.displayqueue)
+        content = IJulia.error_content(e, bt)
+        IJulia.send_ipython(ijulia_kernel.publish[], ijulia_kernel, IJulia.msg_pub(msg, "error", content))
+        content["status"] = "error"
+        content["execution_count"] = ijulia_kernel.n
+        IJulia.send_ipython(
+            ijulia_kernel.requests[],
+            ijulia_kernel,
+            IJulia.msg_reply(msg, "execute_reply", content),
+        )
+    end
 end
 
 """

--- a/julia/Positron/src/ui.jl
+++ b/julia/Positron/src/ui.jl
@@ -35,6 +35,10 @@ function init!(service::UIService, comm::PositronComm)
 
     on_msg!(comm, msg -> handle_ui_msg(service, msg))
     on_close!(comm, () -> handle_ui_close(service))
+
+    # The frontend keeps the console's prompt state across kernel restarts;
+    # make sure a fresh kernel never starts behind a stale `pkg>` prompt.
+    set_console_prompts!(service, JULIA_INPUT_PROMPT, JULIA_CONTINUATION_PROMPT)
 end
 
 """
@@ -287,6 +291,25 @@ function poll_working_directory!(service::UIService)
     params = UiWorkingDirectoryParams(alias_home(current_dir))
     send_event(service.comm, "working_directory", params)
     kernel_log_info("Sent working_directory event: $(params.directory)")
+end
+
+"""
+Update the console's input and continuation prompts (e.g. when entering or
+leaving Pkg REPL mode). No-op when the UI comm is not connected.
+"""
+function set_console_prompts!(
+    service::UIService,
+    input_prompt::String,
+    continuation_prompt::String,
+)
+    if service.comm === nothing
+        kernel_log_warn("UI comm not initialized, cannot update console prompts")
+        return
+    end
+
+    params = UiPromptStateParams(input_prompt, continuation_prompt)
+    send_event(service.comm, "prompt_state", params)
+    kernel_log_info("Sent prompt_state event: $(input_prompt)")
 end
 
 """

--- a/julia/Positron/test/test_kernel.jl
+++ b/julia/Positron/test/test_kernel.jl
@@ -228,4 +228,35 @@ end
         # Unicode
         @test Positron.check_code_complete("α = 1; β = 2; γ = α + β") == "complete"
     end
+
+    @testset "REPL special modes" begin
+        # Pkg mode (issue #35), help mode, and shell mode never parse as
+        # Julia syntax but execute through IJulia's special-mode handling,
+        # so the console must treat them as complete input.
+        @test Positron.check_code_complete("]") == "complete"
+        @test Positron.check_code_complete("] add Example") == "complete"
+        @test Positron.check_code_complete("]status") == "complete"
+        @test Positron.check_code_complete("  ] st  ") == "complete"
+        @test Positron.check_code_complete("?println") == "complete"
+        @test Positron.check_code_complete(";ls") == "complete"
+
+        # Multi-line input is never a special mode.
+        @test Positron.check_code_complete("] add Example\nx = 1") == "invalid"
+    end
+end
+
+@testset "extract_pkg_repl_command" begin
+    # Bare `]` means the user tried to enter the interactive Pkg REPL.
+    @test Positron.extract_pkg_repl_command("]") == ""
+    @test Positron.extract_pkg_repl_command("  ]  ") == ""
+
+    # One-line Pkg commands, with or without a space after `]`.
+    @test Positron.extract_pkg_repl_command("] add DataFrames") == "add DataFrames"
+    @test Positron.extract_pkg_repl_command("]st") == "st"
+    @test Positron.extract_pkg_repl_command("  ] update  ") == "update"
+
+    # Not Pkg-mode input.
+    @test Positron.extract_pkg_repl_command("x = [1, 2]") === nothing
+    @test Positron.extract_pkg_repl_command("") === nothing
+    @test Positron.extract_pkg_repl_command("] add Example\nx = 1") === nothing
 end

--- a/julia/Positron/test/test_kernel.jl
+++ b/julia/Positron/test/test_kernel.jl
@@ -246,7 +246,7 @@ end
 end
 
 @testset "extract_pkg_repl_command" begin
-    # Bare `]` means the user tried to enter the interactive Pkg REPL.
+    # Bare `]` means the user wants to enter Pkg REPL mode.
     @test Positron.extract_pkg_repl_command("]") == ""
     @test Positron.extract_pkg_repl_command("  ]  ") == ""
 
@@ -259,4 +259,40 @@ end
     @test Positron.extract_pkg_repl_command("x = [1, 2]") === nothing
     @test Positron.extract_pkg_repl_command("") === nothing
     @test Positron.extract_pkg_repl_command("] add Example\nx = 1") === nothing
+end
+
+@testset "Pkg REPL mode" begin
+    @testset "Prompt" begin
+        prompt = Positron.pkg_repl_prompt()
+        @test endswith(prompt, "pkg>")
+        # Tests run with an active project, so the prompt carries its label.
+        @test startswith(prompt, "(")
+    end
+
+    @testset "Enter and exit" begin
+        @test !Positron.PKG_REPL_MODE[]
+        try
+            # The entry hint prints to stdout; silence it for the test log.
+            redirect_stdout(devnull) do
+                Positron.enter_pkg_repl_mode!()
+            end
+            @test Positron.PKG_REPL_MODE[]
+
+            # While in Pkg mode, any single line is complete input.
+            @test Positron.check_code_complete("add Example") == "complete"
+            @test Positron.check_code_complete("x = ") == "complete"
+        finally
+            Positron.exit_pkg_repl_mode!()
+        end
+        @test !Positron.PKG_REPL_MODE[]
+    end
+
+    @testset "Extension-internal code bypass" begin
+        # Package-pane mutations must run as Julia even while in Pkg mode.
+        @test Positron.is_extension_internal_code(
+            "_PositronPackages._positron_install_packages([\"Example\"])",
+        )
+        @test !Positron.is_extension_internal_code("add DataFrames")
+        @test !Positron.is_extension_internal_code("x = 1")
+    end
 end

--- a/julia/Positron/test/test_kernel.jl
+++ b/julia/Positron/test/test_kernel.jl
@@ -277,6 +277,12 @@ end
                 Positron.enter_pkg_repl_mode!()
             end
             @test Positron.PKG_REPL_MODE[]
+            Positron.exit_pkg_repl_mode!()
+
+            redirect_stdout(devnull) do
+                Positron.enter_pkg_repl_mode!(; show_message = false)
+            end
+            @test Positron.PKG_REPL_MODE[]
 
             # While in Pkg mode, any single line is complete input.
             @test Positron.check_code_complete("add Example") == "complete"

--- a/julia/Positron/test/test_package_helpers.jl
+++ b/julia/Positron/test/test_package_helpers.jl
@@ -8,6 +8,29 @@ using Test
 
 include(normpath(joinpath(@__DIR__, "..", "..", "..", "scripts", "packages", "packages.jl")))
 
+# The script defines everything inside the `_PositronPackages` module so user
+# globals in `Main` cannot shadow the Base names it uses (issue #32). Bring
+# the tested helpers into scope explicitly.
+using ._PositronPackages:
+    _PositronPackage,
+    _POSITRON_DESCRIPTION_BY_PATH,
+    _POSITRON_LICENSE_BY_PATH,
+    _POSITRON_PROJECT_AUTHOR_BY_PATH,
+    _POSITRON_PROJECT_METADATA_BY_PATH,
+    _POSITRON_REGISTRY_LATEST_VERSION_BY_NAME,
+    _positron_detect_license_text,
+    _positron_missing_packages,
+    _positron_package_detail,
+    _positron_package_metadata,
+    _positron_print_json_packages,
+    _positron_read_license_file,
+    _positron_read_package_description,
+    _positron_read_project_author,
+    _positron_read_project_metadata,
+    _positron_registry_package_url,
+    _positron_stdlib_module_docstring,
+    _positron_version_outdated
+
 function _capture_package_helper_stdout(callback)::String
     path = tempname()
     try
@@ -313,6 +336,30 @@ end
         mktempdir() do package_dir
             @test _positron_read_license_file(package_dir) == ""
         end
+    end
+
+    @testset "Immune to Main Shadowing" begin
+        # Issue #32: a user variable named `values` (or any other Base name)
+        # in the module that includes the script must not break the helpers,
+        # which used to be defined directly in that module and so resolved
+        # `values(...)` against the user's binding. Simulated in a scratch
+        # module standing in for the user's Main: pre-1.12 Julia forbids
+        # assigning over an already-resolved imported binding in the real
+        # Main, so the real thing cannot be shadowed from within the tests.
+        script = normpath(
+            joinpath(@__DIR__, "..", "..", "..", "scripts", "packages", "packages.jl"),
+        )
+        user_main = Module(:PositronShadowedMain)
+        Base.include(user_main, script)
+        Core.eval(user_main, :(values = [3, 7, 2, 5, 4]))
+
+        # Same call shape the extension sends to the kernel.
+        json = _capture_package_helper_stdout() do
+            Core.eval(user_main, :(_PositronPackages._positron_list_packages()))
+        end
+        parsed = JSON3.read(json, Vector{Dict{String, Any}})
+        @test !isempty(parsed)
+        @test all(haskey(p, "name") for p in parsed)
     end
 
     @testset "Missing Packages Detection" begin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "positron-julia",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "positron-julia",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "semver": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "positron-julia",
   "displayName": "Julia for Positron",
   "description": "Julia language support for Positron IDE",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "publisher": "ntluong95",
   "author": "TidierOrg, rdboyes, ntluong95",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "onLanguageRuntime:julia",
     "onLanguage:julia",
     "onCommand:julia.createNewFile",
+    "onCommand:julia.createNewPackage",
     "onCommand:julia.selectInterpreter",
     "onCommand:julia.runFile",
     "onCommand:julia.runSelection",
@@ -122,6 +123,11 @@
         "command": "julia.createNewFile",
         "category": "Julia",
         "title": "New Julia File"
+      },
+      {
+        "command": "julia.createNewPackage",
+        "category": "Julia",
+        "title": "Create New Package"
       },
       {
         "command": "julia.selectInterpreter",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "onCommand:julia.changeCurrentEnvironment",
     "onCommand:julia.executeCell",
     "onCommand:julia.executeCellAndMove",
+    "onCommand:julia.enterPkgReplModeFromConsole",
+    "onCommand:julia.exitPkgReplModeFromConsole",
     "onCommand:julia.stopTestProcess",
     "onCommand:julia.stopTestController",
     "onCommand:julia.runEditorContents",
@@ -188,6 +190,16 @@
         "title": "Execute Code Cell and Move to Next"
       },
       {
+        "command": "julia.enterPkgReplModeFromConsole",
+        "category": "Julia",
+        "title": "Enter Pkg REPL Mode"
+      },
+      {
+        "command": "julia.exitPkgReplModeFromConsole",
+        "category": "Julia",
+        "title": "Exit Pkg REPL Mode"
+      },
+      {
         "command": "julia.stopTestProcess",
         "category": "Julia",
         "title": "Stop Test Process",
@@ -281,6 +293,16 @@
         "command": "julia.executeCellAndMove",
         "key": "alt+shift+enter",
         "when": "editorLangId == julia && editorTextFocus"
+      },
+      {
+        "command": "julia.enterPkgReplModeFromConsole",
+        "key": "]",
+        "when": "positronConsoleFocused && textInputFocus && !positronConsoleFindInputFocused && !suggestWidgetVisible && positronConsoleInputCursorBoundary == both && !positronJuliaPkgReplMode"
+      },
+      {
+        "command": "julia.exitPkgReplModeFromConsole",
+        "key": "backspace",
+        "when": "positronConsoleFocused && textInputFocus && !positronConsoleFindInputFocused && positronConsoleInputCursorBoundary == both && positronJuliaPkgReplMode"
       }
     ],
     "configuration": {

--- a/scripts/packages/create_package.jl
+++ b/scripts/packages/create_package.jl
@@ -1,0 +1,108 @@
+# ---------------------------------------------------------------------------------------------
+# Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+# ---------------------------------------------------------------------------------------------
+
+# Scaffolds a new Julia package with PkgTemplates. Run as a subprocess by the
+# "Julia: Create New Package" command with a dedicated `--project` environment
+# so PkgTemplates is never installed into the user's own projects:
+#
+#   julia --project=<helper-env> create_package.jl <name> <parent_dir> <github_user> <plugins>
+#
+# <plugins> is a comma-separated subset of: git, license, ci, docs.
+# <github_user> may be empty; PkgTemplates requires it for the git/ci/docs
+# plugins (remote URLs and badges), and the extension prompts for it when any
+# of those is selected.
+#
+# Prints `CREATED <path>` on success (`CREATED-FALLBACK <path>` when PkgTemplates
+# was unavailable and the package was scaffolded with Pkg.generate instead).
+
+import Pkg
+
+length(ARGS) >= 4 ||
+    error("usage: create_package.jl <name> <parent_dir> <github_user> <plugins>")
+
+const PKG_NAME = ARGS[1]
+const PARENT_DIR = ARGS[2]
+const GITHUB_USER = ARGS[3]
+const SELECTED = Set(String.(split(ARGS[4], ','; keepempty = true)))
+const TARGET = joinpath(PARENT_DIR, PKG_NAME)
+
+isdir(TARGET) && error("Target directory already exists: $TARGET")
+
+function ensure_pkgtemplates()::Bool
+    if Base.find_package("PkgTemplates") === nothing
+        @info "Installing PkgTemplates into the helper environment (first run only)"
+        try
+            Pkg.add("PkgTemplates")
+        catch err
+            @warn "Could not install PkgTemplates" exception = err
+            return false
+        end
+    end
+    return true
+end
+
+# Local-first plugin set built on top of the PkgTemplates defaults. Registry
+# automation (CompatHelper, TagBot) is left out: it only makes sense for
+# registered packages and can be added by hand later. Referenced lazily so
+# this file loads even without PkgTemplates.
+function build_plugins()
+    plugins = Any[!PkgTemplates.CompatHelper, !PkgTemplates.TagBot]
+
+    "git" in SELECTED || push!(plugins, !PkgTemplates.Git)
+
+    if "license" in SELECTED
+        push!(plugins, PkgTemplates.License(name = "MIT"))
+    else
+        push!(plugins, !PkgTemplates.License)
+    end
+
+    if "ci" in SELECTED
+        push!(plugins, PkgTemplates.GitHubActions())
+    else
+        # Both are defaults in recent PkgTemplates versions; Dependabot only
+        # manages the CI workflow versions, so it goes with the ci option.
+        push!(plugins, !PkgTemplates.GitHubActions)
+        if isdefined(PkgTemplates, :Dependabot)
+            push!(plugins, !PkgTemplates.Dependabot)
+        end
+    end
+
+    if "docs" in SELECTED
+        if "ci" in SELECTED
+            push!(plugins, PkgTemplates.Documenter{PkgTemplates.GitHubActions}())
+        else
+            push!(plugins, PkgTemplates.Documenter())
+        end
+    end
+
+    return plugins
+end
+
+function generate_with_pkgtemplates()
+    kwargs = Dict{Symbol, Any}(:dir => PARENT_DIR, :plugins => build_plugins())
+    isempty(GITHUB_USER) || (kwargs[:user] = GITHUB_USER)
+    template = PkgTemplates.Template(; kwargs...)
+    template(PKG_NAME)
+    println("CREATED ", TARGET)
+end
+
+function generate_fallback()
+    @warn "Falling back to Pkg.generate (PkgTemplates unavailable)"
+    Pkg.generate(TARGET)
+    println("CREATED-FALLBACK ", TARGET)
+end
+
+# Each of the following runs as its own top-level statement so the world age
+# advances in between: code executed after the conditional import sees the
+# PkgTemplates bindings without any invokelatest juggling.
+const HAVE_PKGTEMPLATES = ensure_pkgtemplates()
+
+HAVE_PKGTEMPLATES && @eval(import PkgTemplates)
+
+if HAVE_PKGTEMPLATES
+    generate_with_pkgtemplates()
+else
+    generate_fallback()
+end

--- a/scripts/packages/packages.jl
+++ b/scripts/packages/packages.jl
@@ -3,6 +3,12 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 # ---------------------------------------------------------------------------------------------
 
+# The helpers live in a module (instead of directly in `Main`) so that
+# unqualified Base names used here — `values`, `keys`, `filter`, ... —
+# always resolve to Base, even when the user shadows them with globals in
+# `Main` (e.g. `values = [3, 7, 2]`). See issue #32.
+module _PositronPackages
+
 import Pkg
 import TOML
 
@@ -1017,3 +1023,5 @@ function _positron_search_package_versions(name::String)
     sorted_versions = sort!(collect(versions); rev=true)
     _positron_print_json_string_array(string.(sorted_versions))
 end
+
+end # module _PositronPackages

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import * as positron from "positron";
 
 import { JuliaRuntimeManager } from "./runtime-manager";
+import { createNewPackage } from "./create-package";
 import { LOGGER, getLanguageClient, restartLanguageServer } from "./extension";
 
 const JULIA_LANGUAGE_ID = "julia";
@@ -142,6 +143,18 @@ export function registerCommands(
         content: "",
       });
       await vscode.window.showTextDocument(document);
+    }),
+  );
+
+  // Create a new Julia package scaffold with PkgTemplates (issue #31)
+  context.subscriptions.push(
+    vscode.commands.registerCommand("julia.createNewPackage", async () => {
+      try {
+        await createNewPackage(context, runtimeManager);
+      } catch (error) {
+        LOGGER.error(`Failed to create Julia package: ${error}`);
+        vscode.window.showErrorMessage("Failed to create Julia package");
+      }
     }),
   );
 

--- a/src/create-package.ts
+++ b/src/create-package.ts
@@ -1,0 +1,348 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as cp from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { JuliaInstallation } from "./julia-installation";
+import { JuliaRuntimeManager } from "./runtime-manager";
+import { LOGGER } from "./extension";
+
+/** Template options offered in the multi-select quick pick. */
+interface PackageOptionItem extends vscode.QuickPickItem {
+  id: "git" | "license" | "ci" | "docs";
+}
+
+/**
+ * Interactive "create a new Julia package" flow (issue #31): asks for a name,
+ * a parent folder, and template options, then scaffolds the package with
+ * PkgTemplates in a Julia subprocess. PkgTemplates lives in a dedicated
+ * helper environment under the extension's global storage, so the user's own
+ * environments are never touched.
+ */
+export async function createNewPackage(
+  context: vscode.ExtensionContext,
+  runtimeManager: JuliaRuntimeManager,
+): Promise<void> {
+  const installation = runtimeManager.getPreferredInstallation();
+  if (!installation) {
+    vscode.window.showErrorMessage(
+      "No Julia installation found. Start a Julia interpreter first.",
+    );
+    return;
+  }
+
+  const name = await promptPackageName();
+  if (!name) {
+    return;
+  }
+
+  const parentDir = await promptParentFolder();
+  if (!parentDir) {
+    return;
+  }
+
+  const targetDir = path.join(parentDir, name);
+  if (fs.existsSync(targetDir)) {
+    vscode.window.showErrorMessage(
+      `Cannot create package: ${targetDir} already exists.`,
+    );
+    return;
+  }
+
+  const hasGitIdentity = await checkGitIdentity();
+  const options = await promptTemplateOptions(hasGitIdentity);
+  if (!options) {
+    return;
+  }
+
+  let githubUser = "";
+  if (options.has("git") || options.has("ci") || options.has("docs")) {
+    // PkgTemplates needs a hosting-service username for these plugins (git
+    // remote URLs, CI badges, docs links). Prefer the one configured in git
+    // (`git config github.user`), else ask.
+    githubUser = (await readGitConfig("github.user")) ?? "";
+    if (!githubUser) {
+      const input = await vscode.window.showInputBox({
+        title: "GitHub Username",
+        prompt:
+          "Used for the git remote URL and badges (required by the selected options)",
+        ignoreFocusOut: true,
+        validateInput: (value) =>
+          value.trim().length === 0
+            ? "A GitHub username is required for the selected options"
+            : undefined,
+      });
+      if (input === undefined) {
+        return;
+      }
+      githubUser = input.trim();
+    }
+  }
+
+  const scriptPath = path.join(
+    context.extensionPath,
+    "scripts",
+    "packages",
+    "create_package.jl",
+  );
+  const helperEnvDir = path.join(
+    context.globalStorageUri.fsPath,
+    "pkgtemplates-env",
+  );
+  fs.mkdirSync(helperEnvDir, { recursive: true });
+
+  const result = await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `Creating Julia package '${name}'...`,
+      cancellable: true,
+    },
+    (progress, token) =>
+      runCreatePackageScript(
+        installation,
+        scriptPath,
+        helperEnvDir,
+        name,
+        parentDir,
+        githubUser,
+        options,
+        progress,
+        token,
+      ),
+  );
+
+  if (result === "cancelled") {
+    return;
+  }
+
+  if (result === "failed" || !fs.existsSync(targetDir)) {
+    vscode.window
+      .showErrorMessage(
+        `Failed to create Julia package '${name}'. See the output log for details.`,
+        "Show Log",
+      )
+      .then((choice) => {
+        if (choice === "Show Log") {
+          LOGGER.show();
+        }
+      });
+    return;
+  }
+
+  const message =
+    result === "fallback"
+      ? `Created Julia package '${name}' with Pkg.generate (PkgTemplates was unavailable).`
+      : `Created Julia package '${name}'.`;
+  const action = await vscode.window.showInformationMessage(
+    message,
+    "Open in New Window",
+    "Add to Workspace",
+  );
+  const targetUri = vscode.Uri.file(targetDir);
+  if (action === "Open in New Window") {
+    await vscode.commands.executeCommand("vscode.openFolder", targetUri, {
+      forceNewWindow: true,
+    });
+  } else if (action === "Add to Workspace") {
+    vscode.workspace.updateWorkspaceFolders(
+      vscode.workspace.workspaceFolders?.length ?? 0,
+      0,
+      { uri: targetUri },
+    );
+  }
+}
+
+async function promptPackageName(): Promise<string | undefined> {
+  const input = await vscode.window.showInputBox({
+    title: "New Julia Package",
+    prompt: "Package name",
+    placeHolder: "MyPackage",
+    ignoreFocusOut: true,
+    validateInput: (value) => {
+      const trimmed = value.trim().replace(/\.jl$/i, "");
+      if (trimmed.length === 0) {
+        return "Package name is required";
+      }
+      if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(trimmed)) {
+        return "Package names must start with a letter and contain only letters, digits, and underscores";
+      }
+      if (!/^[A-Z]/.test(trimmed)) {
+        return {
+          message:
+            "Julia package names conventionally start with an uppercase letter",
+          severity: vscode.InputBoxValidationSeverity.Warning,
+        };
+      }
+      return undefined;
+    },
+  });
+
+  if (input === undefined) {
+    return undefined;
+  }
+  // Accept "MyPackage.jl" as a convenience; the directory and module are
+  // always the bare name.
+  return input.trim().replace(/\.jl$/i, "");
+}
+
+async function promptParentFolder(): Promise<string | undefined> {
+  const defaultUri =
+    vscode.workspace.workspaceFolders?.[0]?.uri ?? vscode.Uri.file(os.homedir());
+  const folders = await vscode.window.showOpenDialog({
+    title: "Select the folder to create the package in",
+    openLabel: "Create Package Here",
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+    defaultUri,
+  });
+  return folders?.[0]?.fsPath;
+}
+
+async function promptTemplateOptions(
+  hasGitIdentity: boolean,
+): Promise<Set<string> | undefined> {
+  const items: PackageOptionItem[] = [
+    {
+      id: "git",
+      label: "Git repository",
+      description: hasGitIdentity
+        ? "Initialize a git repository with an initial commit"
+        : "Requires git user.name and user.email to be configured",
+      picked: hasGitIdentity,
+    },
+    {
+      id: "license",
+      label: "MIT license",
+      description: "Add an MIT LICENSE file",
+      picked: true,
+    },
+    {
+      id: "ci",
+      label: "GitHub Actions CI",
+      description: "Add a workflow that runs the package tests",
+      picked: false,
+    },
+    {
+      id: "docs",
+      label: "Documenter.jl docs",
+      description: "Scaffold a docs/ site built with Documenter.jl",
+      picked: false,
+    },
+  ];
+
+  const picked = await vscode.window.showQuickPick(items, {
+    title: "Package Template Options",
+    placeHolder: "Select what to include (tests and README are always included)",
+    canPickMany: true,
+    ignoreFocusOut: true,
+  });
+
+  if (picked === undefined) {
+    return undefined;
+  }
+  return new Set(picked.map((item) => item.id));
+}
+
+function runCreatePackageScript(
+  installation: JuliaInstallation,
+  scriptPath: string,
+  helperEnvDir: string,
+  name: string,
+  parentDir: string,
+  githubUser: string,
+  options: Set<string>,
+  progress: vscode.Progress<{ message?: string }>,
+  token: vscode.CancellationToken,
+): Promise<"created" | "fallback" | "failed" | "cancelled"> {
+  return new Promise((resolve) => {
+    const args = [
+      "--startup-file=no",
+      "--history-file=no",
+      "--color=no",
+      `--project=${helperEnvDir}`,
+      scriptPath,
+      name,
+      parentDir,
+      githubUser,
+      Array.from(options).join(","),
+    ];
+
+    LOGGER.info(
+      `Creating Julia package: ${installation.binpath} ${args.join(" ")}`,
+    );
+    progress.report({
+      message: "This may take a few minutes on first run",
+    });
+
+    const proc = cp.spawn(installation.binpath, args);
+    let sawFallback = false;
+    let stderrTail = "";
+
+    proc.stdout.on("data", (data: Buffer) => {
+      const text = data.toString();
+      if (text.includes("CREATED-FALLBACK")) {
+        sawFallback = true;
+      }
+      LOGGER.info(`[Create Package] ${text.trim()}`);
+    });
+
+    proc.stderr.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stderrTail = (stderrTail + text).slice(-4000);
+      LOGGER.info(`[Create Package] ${text.trim()}`);
+      // PkgTemplates logs progress to stderr; surface the latest line in
+      // the notification so long installs don't look stuck.
+      const lastLine = text.trim().split("\n").pop();
+      if (lastLine) {
+        progress.report({ message: lastLine.slice(0, 80) });
+      }
+    });
+
+    token.onCancellationRequested(() => {
+      proc.kill();
+      resolve("cancelled");
+    });
+
+    proc.on("error", (error) => {
+      LOGGER.error(`Failed to spawn Julia for package creation: ${error}`);
+      resolve("failed");
+    });
+
+    proc.on("close", (code) => {
+      if (token.isCancellationRequested) {
+        resolve("cancelled");
+        return;
+      }
+      if (code === 0) {
+        resolve(sawFallback ? "fallback" : "created");
+      } else {
+        LOGGER.error(
+          `Package creation exited with code ${code}: ${stderrTail}`,
+        );
+        resolve("failed");
+      }
+    });
+  });
+}
+
+/** Whether git has user.name and user.email configured (needed by the Git plugin). */
+async function checkGitIdentity(): Promise<boolean> {
+  const name = await readGitConfig("user.name");
+  const email = await readGitConfig("user.email");
+  return Boolean(name && email);
+}
+
+function readGitConfig(key: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    cp.execFile("git", ["config", "--get", key], (error, stdout) => {
+      resolve(error ? undefined : stdout.trim() || undefined);
+    });
+  });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { JuliaEnvironmentManager } from './environment';
 import { TestFeature } from './testing/testFeature';
 import { notifyTypeTextDocumentPublishTests } from './testing/testLSProtocol';
 import { registerDebugFeature } from './debugger/debugFeature';
+import { registerPkgReplConsoleKeybindings } from './pkg-repl-console-keybindings';
 
 export const LOGGER = vscode.window.createOutputChannel('Julia Language Pack', { log: true });
 
@@ -78,6 +79,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register commands
 	registerCommands(context, juliaRuntimeManager);
+	registerPkgReplConsoleKeybindings(context, juliaRuntimeManager);
 
 	// Module-level session getter used by the completion provider and the LSP
 	// repl/getCompletions bridge.

--- a/src/kernel-spec.ts
+++ b/src/kernel-spec.ts
@@ -169,6 +169,14 @@ function getKernelStartupCode(): string {
 				isfile(joinpath(user_project, "JuliaProject.toml"))
 			)
 				Pkg.activate(user_project)
+			else
+				# No valid workspace project: activate() with no arguments
+				# toggles back to whatever was active before the bundled
+				# Positron.jl activation above (the user's default global
+				# environment, e.g. @v1.12). Without this, the console and
+				# Pkg REPL mode would stay pinned to the extension's own
+				# internal project forever.
+				Pkg.activate()
 			end
 		end;
 		IJulia.run_kernel();

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -16,6 +16,11 @@ import { LOGGER } from "./extension";
 const QUERY_TIMEOUT_MS = 2 * 60 * 1000;
 const MUTATION_TIMEOUT_MS = 30 * 60 * 1000;
 
+// The Julia helpers are defined inside this module (see packages.jl) so that
+// the names they use cannot be shadowed by user globals in Main (issue #32).
+// All generated code must reference them through this qualified prefix.
+const HELPER_MODULE = "_PositronPackages";
+
 interface JuliaPackageSession {
   execute(
     code: string,
@@ -129,8 +134,10 @@ export class JuliaPackageManager
       const escapedScriptPath = this._escapeJuliaStringLiteral(
         this._scriptPath,
       );
+      // Base.include instead of bare include: the bare name resolves through
+      // Main and can be shadowed by a user global named `include`.
       await this._executeAndCapture(
-        `include("${escapedScriptPath}")`,
+        `Base.include(Main, "${escapedScriptPath}")`,
         positron.RuntimeCodeExecutionMode.Silent,
         QUERY_TIMEOUT_MS,
       );
@@ -184,7 +191,7 @@ export class JuliaPackageManager
       return;
     }
 
-    const code = `_positron_install_packages(${this._toJuliaStringVector(specs)})`;
+    const code = `${HELPER_MODULE}._positron_install_packages(${this._toJuliaStringVector(specs)})`;
     await this._executeAndWait(code, MUTATION_TIMEOUT_MS, token);
     this._firePackagesChanged(
       this._uniquePackageNames(requested.map((pkg) => pkg.name)),
@@ -206,7 +213,7 @@ export class JuliaPackageManager
     }
 
     await this._executeAndWait(
-      `_positron_uninstall_packages(${this._toJuliaStringVector(names)})`,
+      `${HELPER_MODULE}._positron_uninstall_packages(${this._toJuliaStringVector(names)})`,
       MUTATION_TIMEOUT_MS,
       token,
     );
@@ -230,7 +237,7 @@ export class JuliaPackageManager
     }
 
     await this._executeAndWait(
-      `_positron_update_packages(${this._toJuliaStringVector(names)})`,
+      `${HELPER_MODULE}._positron_update_packages(${this._toJuliaStringVector(names)})`,
       MUTATION_TIMEOUT_MS,
       token,
     );
@@ -242,7 +249,7 @@ export class JuliaPackageManager
     const packagesBefore = await this._listPackagesFromRuntime(token);
 
     await this._executeAndWait(
-      "_positron_update_all_packages()",
+      `${HELPER_MODULE}._positron_update_all_packages()`,
       MUTATION_TIMEOUT_MS,
       token,
     );
@@ -271,7 +278,7 @@ export class JuliaPackageManager
     const escaped = this._escapeJuliaStringLiteral(query);
 
     const raw = await this._executeAndCapture(
-      `_positron_search_packages("${escaped}")`,
+      `${HELPER_MODULE}._positron_search_packages("${escaped}")`,
       positron.RuntimeCodeExecutionMode.Silent,
       QUERY_TIMEOUT_MS,
       token,
@@ -294,7 +301,7 @@ export class JuliaPackageManager
     const escaped = this._escapeJuliaStringLiteral(name);
 
     const raw = await this._executeAndCapture(
-      `_positron_search_package_versions("${escaped}")`,
+      `${HELPER_MODULE}._positron_search_package_versions("${escaped}")`,
       positron.RuntimeCodeExecutionMode.Silent,
       QUERY_TIMEOUT_MS,
       token,
@@ -324,7 +331,7 @@ export class JuliaPackageManager
     await this.sourcePackagesScript();
 
     const raw = await this._executeAndCapture(
-      `_positron_missing_packages(${this._toJuliaStringVector(cleaned)})`,
+      `${HELPER_MODULE}._positron_missing_packages(${this._toJuliaStringVector(cleaned)})`,
       positron.RuntimeCodeExecutionMode.Silent,
       QUERY_TIMEOUT_MS,
       token,
@@ -348,7 +355,7 @@ export class JuliaPackageManager
     await this.sourcePackagesScript();
 
     const raw = await this._executeAndCapture(
-      `_positron_package_metadata(${this._toJuliaStringVector(cleaned)})`,
+      `${HELPER_MODULE}._positron_package_metadata(${this._toJuliaStringVector(cleaned)})`,
       positron.RuntimeCodeExecutionMode.Silent,
       QUERY_TIMEOUT_MS,
       token,
@@ -388,7 +395,7 @@ export class JuliaPackageManager
 
     const escaped = this._escapeJuliaStringLiteral(trimmed);
     const raw = await this._executeAndCapture(
-      `_positron_package_detail("${escaped}")`,
+      `${HELPER_MODULE}._positron_package_detail("${escaped}")`,
       positron.RuntimeCodeExecutionMode.Silent,
       QUERY_TIMEOUT_MS,
       token,
@@ -521,7 +528,7 @@ export class JuliaPackageManager
     stdlibNames?: Set<string>,
   ): Promise<positron.LanguageRuntimePackage[]> {
     const raw = await this._executeAndCapture(
-      "_positron_list_packages()",
+      `${HELPER_MODULE}._positron_list_packages()`,
       positron.RuntimeCodeExecutionMode.Silent,
       QUERY_TIMEOUT_MS,
       token,
@@ -741,17 +748,19 @@ export class JuliaPackageManager
     const escapedPath = this._escapeJuliaStringLiteral(tempFile);
     const escapedPathErr = this._escapeJuliaStringLiteral(tempFileErr);
 
+    // Every function here is Base-qualified: this snippet runs in Main, where
+    // bare names like `open` can be shadowed by user globals (issue #32).
     const wrappedCode =
-      `let __positron_io = open("${escapedPath}", "w"), __positron_err = open("${escapedPathErr}", "w")\n` +
+      `let __positron_io = Base.open("${escapedPath}", "w"), __positron_err = Base.open("${escapedPathErr}", "w")\n` +
       `try\n` +
-      `redirect_stdout(__positron_io) do\n` +
-      `redirect_stderr(__positron_err) do\n` +
+      `Base.redirect_stdout(__positron_io) do\n` +
+      `Base.redirect_stderr(__positron_err) do\n` +
       `${code}\n` +
       `end\n` +
       `end\n` +
       `finally\n` +
-      `close(__positron_io)\n` +
-      `flush(__positron_err)\n` +
+      `Base.close(__positron_io)\n` +
+      `Base.flush(__positron_err)\n` +
       `end\n` +
       `end`;
 

--- a/src/pkg-repl-console-keybindings.ts
+++ b/src/pkg-repl-console-keybindings.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import * as positron from "positron";
+
+import { LOGGER } from "./extension";
+import { JuliaRuntimeManager } from "./runtime-manager";
+import {
+  isJuliaPkgReplModeContext,
+  setJuliaPkgReplModeContext,
+} from "./pkg-repl-console-state";
+
+const JULIA_REPL_INPUT_PATH = /^\/(?:notebook-)?repl-julia-/;
+
+interface ConsoleInputDocument {
+  document: vscode.TextDocument;
+  updatedAt: number;
+}
+
+class JuliaConsoleInputTracker implements vscode.Disposable {
+  private readonly documents = new Map<string, ConsoleInputDocument>();
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor() {
+    for (const document of vscode.workspace.textDocuments) {
+      this.track(document);
+    }
+
+    this.disposables.push(
+      vscode.workspace.onDidOpenTextDocument((document) => this.track(document)),
+      vscode.workspace.onDidChangeTextDocument((event) => this.track(event.document)),
+      vscode.workspace.onDidCloseTextDocument((document) => {
+        this.documents.delete(document.uri.toString());
+      }),
+    );
+  }
+
+  dispose(): void {
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+    this.documents.clear();
+  }
+
+  getMostRecentInput(): string | undefined {
+    let latest: ConsoleInputDocument | undefined;
+    for (const entry of this.documents.values()) {
+      if (!latest || entry.updatedAt > latest.updatedAt) {
+        latest = entry;
+      }
+    }
+    return latest?.document.getText();
+  }
+
+  private track(document: vscode.TextDocument): void {
+    if (!isJuliaConsoleInputDocument(document)) {
+      return;
+    }
+
+    this.documents.set(document.uri.toString(), {
+      document,
+      updatedAt: Date.now(),
+    });
+  }
+}
+
+export function registerPkgReplConsoleKeybindings(
+  context: vscode.ExtensionContext,
+  runtimeManager: JuliaRuntimeManager,
+): void {
+  const tracker = new JuliaConsoleInputTracker();
+  context.subscriptions.push(tracker);
+  setJuliaPkgReplModeContext(false);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("julia.enterPkgReplModeFromConsole", async () => {
+      const session = await getForegroundJuliaSession(runtimeManager);
+      if (!session) {
+        await typeText("]");
+        return;
+      }
+
+      const currentInput = tracker.getMostRecentInput();
+      if (currentInput !== "") {
+        await typeText("]");
+        return;
+      }
+
+      if (executePkgReplModeFunction(session, "enter_pkg_repl_mode!(; show_message = false)")) {
+        setJuliaPkgReplModeContext(true);
+      } else {
+        await typeText("]");
+      }
+    }),
+    vscode.commands.registerCommand("julia.exitPkgReplModeFromConsole", async () => {
+      const session = await getForegroundJuliaSession(runtimeManager);
+      if (!session) {
+        await deleteLeft();
+        return;
+      }
+
+      const currentInput = tracker.getMostRecentInput();
+      if (currentInput !== "" || !isJuliaPkgReplModeContext()) {
+        await deleteLeft();
+        return;
+      }
+
+      if (executePkgReplModeFunction(session, "exit_pkg_repl_mode!()")) {
+        setJuliaPkgReplModeContext(false);
+      } else {
+        await deleteLeft();
+      }
+    }),
+  );
+}
+
+function isJuliaConsoleInputDocument(document: vscode.TextDocument): boolean {
+  return (
+    document.uri.scheme === "inmemory" &&
+    document.languageId === "julia" &&
+    JULIA_REPL_INPUT_PATH.test(document.uri.path)
+  );
+}
+
+async function getForegroundJuliaSession(
+  runtimeManager: JuliaRuntimeManager,
+): Promise<positron.BaseLanguageRuntimeSession | undefined> {
+  const foregroundSession = await positron.runtime.getForegroundSession();
+  if (foregroundSession) {
+    return foregroundSession.runtimeMetadata.languageId === "julia"
+      ? foregroundSession
+      : undefined;
+  }
+
+  return runtimeManager.getActiveJuliaSession();
+}
+
+function executePkgReplModeFunction(
+  session: positron.BaseLanguageRuntimeSession,
+  functionCall: string,
+): boolean {
+  try {
+    session.execute(
+      `Positron.${functionCall}`,
+      `pkg-repl-mode-${Date.now()}`,
+      positron.RuntimeCodeExecutionMode.Silent,
+      positron.RuntimeErrorBehavior.Continue,
+    );
+    return true;
+  } catch (error) {
+    LOGGER.warn(`Failed to dispatch Pkg REPL mode command: ${error}`);
+    return false;
+  }
+}
+
+async function typeText(text: string): Promise<void> {
+  await vscode.commands.executeCommand("type", { text });
+}
+
+async function deleteLeft(): Promise<void> {
+  await vscode.commands.executeCommand("deleteLeft");
+}

--- a/src/pkg-repl-console-state.ts
+++ b/src/pkg-repl-console-state.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+
+export const JULIA_PKG_REPL_MODE_CONTEXT = "positronJuliaPkgReplMode";
+
+let pkgReplModeContext = false;
+
+export function isPkgReplPrompt(inputPrompt: unknown): boolean {
+  return typeof inputPrompt === "string" && inputPrompt.trimEnd().endsWith("pkg>");
+}
+
+export function isJuliaPkgReplModeContext(): boolean {
+  return pkgReplModeContext;
+}
+
+export function setJuliaPkgReplModeContext(enabled: boolean): void {
+  if (pkgReplModeContext === enabled) {
+    return;
+  }
+
+  pkgReplModeContext = enabled;
+  void vscode.commands.executeCommand(
+    "setContext",
+    JULIA_PKG_REPL_MODE_CONTEXT,
+    enabled,
+  );
+}

--- a/src/runtime-manager.ts
+++ b/src/runtime-manager.ts
@@ -43,6 +43,22 @@ export class JuliaRuntimeManager implements positron.LanguageRuntimeManager {
 		return undefined;
 	}
 
+	/**
+	 * Best Julia installation for auxiliary tooling (e.g. the create-package
+	 * command): the active session's installation, else the first discovered
+	 * one.
+	 */
+	getPreferredInstallation(): JuliaInstallation | undefined {
+		const session = this.getActiveJuliaSession();
+		if (session) {
+			return session.installation;
+		}
+		for (const installation of this._installations.values()) {
+			return installation;
+		}
+		return undefined;
+	}
+
 	/** Recommended runtime for the current workspace */
 	private _recommendedRuntime: positron.LanguageRuntimeMetadata | undefined;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -84,6 +84,9 @@ export class JuliaSession
     this.dynState = {
       // Do not put ANSI here. Positron's inputPrompt renderer currently
       // displays ANSI escape sequences literally.
+      // Keep in sync with JULIA_INPUT_PROMPT/JULIA_CONTINUATION_PROMPT in
+      // julia/Positron/src/kernel.jl, which restores these prompts when the
+      // console leaves Pkg REPL mode.
       inputPrompt: "julia>",
       continuationPrompt: "      ",
       sessionName: sessionName || runtimeMetadata.runtimeName,

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,10 @@ import {
 } from "./positron-supervisor";
 import { JuliaPackageManager } from "./packages";
 import { listMissingJuliaPackages } from "./missingPackages";
+import {
+  isPkgReplPrompt,
+  setJuliaPkgReplModeContext,
+} from "./pkg-repl-console-state";
 
 interface RuntimeResourceUsage {
   [key: string]: unknown;
@@ -256,6 +260,7 @@ export class JuliaSession
     // Forward events from the Jupyter session
     this._kernel.onDidReceiveRuntimeMessage(
       (msg: positron.LanguageRuntimeMessage) => {
+        this.updatePkgReplModeContext(msg);
         this._rawMessageEmitter.fire(msg);
         if (!this._suppressedExecutionIds.has(msg.parent_id)) {
           this._messageEmitter.fire(msg);
@@ -330,6 +335,23 @@ export class JuliaSession
     });
 
     return this.runtimeInfo;
+  }
+
+  private updatePkgReplModeContext(msg: positron.LanguageRuntimeMessage): void {
+    if (msg.type !== positron.LanguageRuntimeMessageType.CommData) {
+      return;
+    }
+
+    const data = (msg as positron.LanguageRuntimeCommMessage).data as {
+      method?: unknown;
+      params?: { input_prompt?: unknown };
+    };
+
+    if (data?.method !== "prompt_state") {
+      return;
+    }
+
+    setJuliaPkgReplModeContext(isPkgReplPrompt(data.params?.input_prompt));
   }
 
   execute(


### PR DESCRIPTION
Fixes three issues for the 0.2.0 release: #32, #35, and #31.

## `values` shadowing crash in the package hooks (closes #32)

The package-pane helper script was included directly into `Main`, so every unqualified Base name it used resolved through the user's namespace — `values = [3, 7, 2]` shadowed `Base.values` and made the background `_positron_list_packages()` hook fail with a repeating "Julia package command failed" toast.

- `scripts/packages/packages.jl` now defines everything inside a `_PositronPackages` module, so Base names always resolve to Base regardless of what the user defines in `Main`. This fixes the whole class of shadowing bugs (`values`, `keys`, `filter`, ...), not just the reported one.
- The generated stdout-capture wrapper and the `include` call in `src/packages.ts` are `Base.`-qualified for the same reason (`open`, `redirect_stdout`, `close`, `flush` were equally shadowable).
- Regression test simulates a user `Main` with `values = [3, 7, 2, 5, 4]` and runs the list hook through it.

## Pkg REPL mode in the console (closes #35)

VSCodeServer binds the `]` key in a LineEdit keymap that transitions the terminal REPL into `Pkg.REPLMode`. Positron's console is Jupyter-based and never sees raw keystrokes, so the transition happens on submission instead:

- Submitting `]` enters Pkg REPL mode. The console prompt changes to the environment-aware `(@v1.12) pkg>` / `(MyProject) pkg>` via Positron's `prompt_state` UI event (the same mechanism ark uses for R's `browser()` prompts).
- While in the mode, every submission runs as a Pkg REPL command through `Pkg.REPLMode` (IJulia's version-aware bridge), with output in the console: `status`, `add DataFrames`, `?`, etc.
- `back`, `exit`, or `quit` returns to the `julia>` prompt — the Backspace/Ctrl-C keystrokes that leave the mode in a terminal can't reach a Jupyter kernel, so typed commands replace them (the entry message says so).
- Silent background executions and the extension's package-pane calls bypass the mode; a fresh kernel resets the prompt when the UI comm opens, so a restart never leaves a stale `pkg>` prompt.
- One-shot commands (`] add DataFrames`) still work from the `julia>` prompt, and `check_code_complete` now reports REPL special-mode lines (`]...`, `?foo`, `;ls`) as complete so the console executes them instead of treating them as invalid.

## "Julia: Create New Package" command (closes #31)

New `julia.createNewPackage` command scaffolds a package with [PkgTemplates.jl](https://github.com/JuliaCI/PkgTemplates.jl): prompts for a name (validated), a parent folder, and template options — git repository, MIT license, GitHub Actions CI, Documenter docs; tests and README are always included.

- PkgTemplates runs in a Julia subprocess with a dedicated helper environment under the extension's global storage, so the user's own environments are never touched. First run installs PkgTemplates automatically.
- Falls back to `Pkg.generate` (with a distinct success message) when PkgTemplates cannot be installed, e.g. offline.
- A GitHub username is requested only when a selected option needs one (git remote URLs, badges), preferring `git config github.user`. The git option is pre-selected only when a git identity is configured.
- Registry automation (TagBot, CompatHelper, Dependabot) is intentionally excluded from the scaffold; on success the package can be opened in a new window or added to the workspace.

## Testing

- `Pkg.test("Positron")`: 1001/1001 pass, including new tests for the shadowed-`Main` scenario, Pkg REPL mode enter/exit + completeness, the extension-internal bypass, and `extract_pkg_repl_command`.
- Simulated the full mode flow in a live Julia process: enter → prompt label → `status` output through `Pkg.REPLMode` → exit.
- `tsc` and esbuild bundle are clean.
- `create_package.jl` exercised end-to-end for all three paths: full options (git+license+ci+docs → complete scaffold with initial commits), license-only without a username, and the offline `Pkg.generate` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)