### PR TITLE
Implement missing package probe for Julia errors and update version to 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 - **TestItem Compatible** - Uses the same testing system as `julia-vscode`
 - **Debugger** - Use breakpoints, inspect local and global variables, etc.
 - **Formatting** — Format Document (Shift+Alt+F) and Format Selection (Ctrl+K Ctrl+F) via [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl), powered by the language server. Configurable through a `.JuliaFormatter.toml` file at the workspace root.
+- **Missing Package Prompts** — Detects packages your code references but that aren't installed, and offers to install them from the console, before running a file, and in the editor. See [Missing Package Prompts](#missing-package-prompts) — these rely on Positron preview settings.
 
 ## Requirements
 
@@ -42,7 +43,42 @@ Julia language support for [Positron](https://github.com/posit-dev/positron). Ba
 
 On first launch, the extension automatically installs required Julia packages (`IJulia`, `LanguageServer.jl`, and supporting dependencies). This one-time setup may take a few minutes.
 
+## Missing Package Prompts
+
+When your Julia code references a package that isn't installed, Positron can offer to install it in three places:
+
+| Where | What you see | Positron setting |
+| ----- | ------------ | ---------------- |
+| **Console** | An `Install <Pkg>` suggestion beneath a `Package X not found in current path` error | `packages.suggestInstallOnError` |
+| **Before running a file** | An *Install Missing Packages* dialog listing every missing package, with **Install Packages and Run** | `packages.confirmMissingOnRun` |
+| **Editor** | A `N missing packages` warning badge in the editor action bar | `packages.warnMissingInEditor` |
+
+> [!WARNING]
+> These are **Positron preview features**, not settings contributed by this extension. They require a recent Positron build (reported working on **2026.08.0 build 249** and newer) — on older builds the settings don't exist and no prompts appear, regardless of this extension's version.
+>
+> All three default to `true`, so normally no configuration is needed. If a prompt doesn't appear, open **Settings** and search for `packages.` to confirm the relevant setting above is enabled — each surface is gated *independently*, so the console suggestion can work while the editor badge is switched off.
+
+To enable them explicitly, add to your `settings.json`:
+
+```jsonc
+{
+  // Suggest installing a package when a console error reports it missing
+  "packages.suggestInstallOnError": true,
+  // Offer to install missing packages before running a file or notebook
+  "packages.confirmMissingOnRun": true,
+  // Show the "N missing packages" badge in the editor action bar
+  "packages.warnMissingInEditor": true
+}
+```
+
+Notes:
+
+- The prompts only offer packages that exist in a reachable registry, so unregistered or GitHub-only packages are never suggested.
+- The editor badge needs a **running Julia console session** for the open file — it stays hidden until a session is started. It also hides itself when the editor action bar is too narrow to fit it.
+
 ## Extension Settings
+
+Contributed by this extension:
 
 | Setting                                         | Default | Description                                                 |
 | ----------------------------------------------- | ------- | ----------------------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "positron-julia",
   "displayName": "Julia for Positron",
   "description": "Julia language support for Positron IDE",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "ntluong95",
   "author": "TidierOrg, rdboyes, ntluong95",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "positron-julia",
   "displayName": "Julia for Positron",
   "description": "Julia language support for Positron IDE",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "ntluong95",
   "author": "TidierOrg, rdboyes, ntluong95",
   "contributors": [

--- a/src/missingPackages.ts
+++ b/src/missingPackages.ts
@@ -75,6 +75,21 @@ export function parseJuliaPackageReferences(code: string): string[] {
   return [...packages];
 }
 
+/** Julia: `ArgumentError: Package Foo not found in current path.` */
+const JULIA_MISSING_PACKAGE_REGEX =
+  /ArgumentError: Package (\S+) not found in current path/;
+
+/**
+ * Build a probe snippet (`using Foo`) from a Julia missing-package error, or
+ * undefined when the message is not a missing-package error.
+ */
+export function juliaMissingPackageProbe(
+  errorMessage: string,
+): string | undefined {
+  const name = JULIA_MISSING_PACKAGE_REGEX.exec(errorMessage)?.[1];
+  return name ? `using ${name}` : undefined;
+}
+
 /**
  * The subset of JuliaPackageManager that the missing-packages analyzer
  * needs: a single kernel round-trip that filters candidate names down to

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,7 +13,10 @@ import {
   JupyterKernelSpec,
 } from "./positron-supervisor";
 import { JuliaPackageManager } from "./packages";
-import { listMissingJuliaPackages } from "./missingPackages";
+import {
+  listMissingJuliaPackages,
+  juliaMissingPackageProbe,
+} from "./missingPackages";
 import {
   isPkgReplPrompt,
   setJuliaPkgReplModeContext,
@@ -512,6 +515,12 @@ export class JuliaSession
     token?: vscode.CancellationToken,
   ): Promise<positron.RuntimeMissingPackage[]> {
     return listMissingJuliaPackages(this._packageManager, target, token);
+  }
+
+  getMissingPackageProbe(
+    error: positron.RuntimeConsoleError,
+  ): string | undefined {
+    return juliaMissingPackageProbe(error.message);
   }
 
   updateSessionName(name: string): void {

--- a/typings/positron.d.ts
+++ b/typings/positron.d.ts
@@ -1249,6 +1249,21 @@ declare module 'positron' {
 		 * @param token Optional cancellation token.
 		 */
 		listMissingPackages?(target: RuntimeMissingPackagesTarget, token?: vscode.CancellationToken): Thenable<RuntimeMissingPackage[]>;
+
+		/**
+		 * Given a console error produced by this session, return a minimal code
+		 * snippet that references the missing package (e.g. `import foo`), for
+		 * the frontend to feed back through `listMissingPackages` and confirm the
+		 * package is installable. Return undefined when the error is not a
+		 * recognized missing-package error.
+		 *
+		 * Owning error-message parsing here (rather than in the frontend) keeps
+		 * the frontend language-agnostic.
+		 *
+		 * @param error The console error to inspect.
+		 * @param token Optional cancellation token.
+		 */
+		getMissingPackageProbe?(error: RuntimeConsoleError, token?: vscode.CancellationToken): string | undefined | Thenable<string | undefined>;
 	}
 
 	/**
@@ -1276,6 +1291,19 @@ declare module 'positron' {
 
 		/** URI of a saved file to analyze. The runtime may read/parse it directly. */
 		readonly uri?: string;
+	}
+
+	/**
+	 * A runtime error surfaced in the console, passed to `getMissingPackageProbe`
+	 * so the runtime can recognize its own missing-package error format.
+	 */
+	export interface RuntimeConsoleError {
+		/** The error name, e.g. "ModuleNotFoundError". May be empty. */
+		readonly name: string;
+		/** The error message, e.g. "No module named 'foo'". */
+		readonly message: string;
+		/** The error traceback, one entry per line. */
+		readonly traceback: string[];
 	}
 
 	/**


### PR DESCRIPTION
Introduce a new function to generate a probe snippet for missing Julia packages based on error messages. Bump the version to 0.2.2 to reflect these changes.