### PR TITLE
ci: run Positron API tests on ubuntu-latest

### DIFF
--- a/.github/workflows/positron-api-tests.yaml
+++ b/.github/workflows/positron-api-tests.yaml
@@ -18,8 +18,7 @@ env:
 jobs:
   test:
     name: Positron API Tests
-    # @posit-dev/positron-test-electron currently supports macOS only.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -46,18 +45,19 @@ jobs:
         id: cache
         with:
           path: .positron-test
-          key: positron-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
+          key: positron-${{ runner.os }}-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
 
       - run: npm ci
 
       - name: Run Positron API tests
-        uses: posit-dev/setup-positron@main
+        uses: posit-dev/setup-positron@v1
         with:
           positron-channel: ${{ env.POSITRON_CHANNEL }}
-          run: npm run test-positron
+          # Positron is an Electron app and needs a display server on Linux.
+          run: xvfb-run -a npm run test-positron
 
       - uses: actions/cache/save@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: .positron-test
-          key: positron-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
+          key: positron-${{ runner.os }}-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "which": "^3.0.0"
       },
       "devDependencies": {
-        "@posit-dev/positron-test-electron": "^0.0.2",
+        "@posit-dev/positron-test-electron": "^0.0.3",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "14.x",
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/@posit-dev/positron-test-electron": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.2.tgz",
-      "integrity": "sha512-betE+lg9R6qom5cHafmimF9bJ9yWUhATj9JxzRNDAPCh9CLisQ8iSxfIv+RL+x+r7frGT0H018Y7ekb4JxW2vA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.3.tgz",
+      "integrity": "sha512-MQYKCoB9JlGd70QLV0BVTezzGljIduLskeczDLVZ/4ECuYKAtuVFHvXFLDv5BUoarSxHkc0cT6r9k7DwrSni3A==",
       "dev": true,
       "dependencies": {
         "@vscode/test-electron": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -604,7 +604,7 @@
     "verify": "npm run bundle && npm run package"
   },
   "devDependencies": {
-    "@posit-dev/positron-test-electron": "^0.0.2",
+    "@posit-dev/positron-test-electron": "^0.0.3",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "14.x",

--- a/scripts/run-positron-tests.mjs
+++ b/scripts/run-positron-tests.mjs
@@ -9,9 +9,9 @@
 // first via the `pretest-positron` hook. Set POSITRON_CHANNEL=daily to test
 // against a daily Positron build (default: stable).
 //
-// NOTE: @posit-dev/positron-test-electron currently supports macOS only
-// (arm64 + x64); Windows/Linux support is planned upstream. On other
-// platforms, rely on the "Positron API Tests" GitHub Actions workflow.
+// NOTE: on Linux, Positron is an Electron app and needs a display server, so
+// wrap the command in `xvfb-run` when running headless (as the "Positron API
+// Tests" GitHub Actions workflow does).
 
 import { runTests } from "@posit-dev/positron-test-electron";
 import * as path from "node:path";

--- a/src/test/positron/README.md
+++ b/src/test/positron/README.md
@@ -30,11 +30,17 @@ npm run test-positron                          # against the latest stable Posit
 POSITRON_CHANNEL=daily npm run test-positron   # against a daily build
 ```
 
-> **Note:** `@posit-dev/positron-test-electron` currently supports **macOS only**
-> (arm64 + x64). On Windows/Linux, rely on the `Positron API Tests` GitHub
-> Actions workflow (`.github/workflows/positron-api-tests.yaml`), which runs on
-> every PR and push to `main`. The workflow installs Julia (via
-> `julia-actions/setup-julia`) so runtime discovery has a Julia to find.
+On Linux, Positron needs a display server, so run it under `xvfb-run` when
+headless:
+
+```bash
+xvfb-run -a npm run test-positron
+```
+
+> **Note:** the suite also runs in CI on every PR and push to `main` via the
+> `Positron API Tests` workflow (`.github/workflows/positron-api-tests.yaml`),
+> which installs Julia (via `julia-actions/setup-julia`) so runtime discovery has
+> a Julia to find.
 
 ## The tests
 


### PR DESCRIPTION
## What

Moves the `Positron API Tests` workflow from `macos-latest` to `ubuntu-latest`.

## Why

When these tests landed in #41, the test runner
([`@posit-dev/positron-test-electron`](https://github.com/posit-dev/positron-test-electron))
could only download macOS builds of Positron, so the job had to run on a macOS
runner. Version `0.0.3` adds Windows and Linux support, and Positron now
publishes the Linux archives it needs — so the macOS constraint is gone.

Linux is the cheapest runner tier GitHub offers — a tenth of the minute
multiplier of macOS — and the runners are more plentiful, so jobs start sooner.
This repo is public, so standard runners are free either way; the win is faster
starts, a shorter job, and not holding a scarce macOS runner for work that
doesn't need one.

## Changes

- `.github/workflows/positron-api-tests.yaml`
  - `runs-on: macos-latest` → `ubuntu-latest` (and drop the now-stale
    "macOS only" comment).
  - Run the test command under `xvfb-run -a`. Positron is an Electron app, and
    on Linux it needs a display server — without this it fails with
    `Missing X server or $DISPLAY`.
  - Pin `posit-dev/setup-positron` to the `v1` tag instead of tracking `main`,
    so future changes to that action can't break this repo's CI unannounced.
  - Include `runner.os` in the Positron download cache key. The archive layout
    differs per platform, so a cache saved by one OS shouldn't count as a hit
    for another. (Happy to drop this one if you'd rather keep the diff to the
    runner switch.)
- `package.json` / `package-lock.json` — bump
  `@posit-dev/positron-test-electron` `^0.0.2` → `^0.0.3` (the version that
  added Linux support).
- `scripts/run-positron-tests.mjs`, `src/test/positron/README.md` — refresh the
  "macOS only" notes, which are no longer true, and document the `xvfb-run`
  requirement for running the suite locally on Linux.

No test code changed.

## Verification

Green on `ubuntu-latest` in my fork: https://github.com/jonvanausdeln/positron-julia/actions/runs/32173307802

All 4 tests pass in a real Positron (stable `2026.08.1-2`) on Linux — the
extension activates and a Julia runtime surfaces via `getRegisteredRuntimes` /
`getPreferredRuntime`, the same assertions that were passing on macOS. The job
took **1m23s**, versus about 2 minutes for the recent `macos-latest` runs on
`main`.

